### PR TITLE
Made all functions nothrow

### DIFF
--- a/deimos/zmq/utils.d
+++ b/deimos/zmq/utils.d
@@ -22,7 +22,7 @@ module deimos.zmq.utils;
 
 import core.stdc.config;
 
-extern (C)
+nothrow extern (C)
 {
 
 /*Handle DSO symbol visibility  */

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -22,7 +22,7 @@ module deimos.zmq.zmq;
 
 import core.stdc.config;
 
-extern (C)
+nothrow extern (C)
 {
 
 /******************************************************************************/
@@ -132,8 +132,8 @@ struct zmq_msg_t { ubyte[32] _; }
 
 int zmq_msg_init(zmq_msg_t* msg);
 int zmq_msg_init_size(zmq_msg_t* msg, size_t size);
-int zmq_msg_init_data(zmq_msg_t* msg, void* data,
-    size_t size, void function(void* data, void* hint), void* hint);
+int zmq_msg_init_data(zmq_msg_t* msg, void* data, size_t size,
+    void function(void* data, void* hint) nothrow ffn, void* hint);
 int zmq_msg_send(zmq_msg_t* msg, void* s, int flags);
 int zmq_msg_recv(zmq_msg_t* msg, void* s, int flags);
 int zmq_msg_close(zmq_msg_t* msg);


### PR DESCRIPTION
`zmq_msg_init_data()` takes a callback, which must also be `nothrow` if the function itself is `nothrow`. Alternatively, `zmq_msg_init_data()` _and_ the callback could be allowed to throw, but since the function is most likely not written with this in mind, making everyhing `nothrow` seems like the safest choice.
