### PR TITLE
correct package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-        "name": "ZeroMQ",
+        "name": "zeromq",
         "description": "Interface to the C ZeroMQ library",
         "homepage": "http://github.com/D-Programming-Deimos/ZeroMQ",
         "authors": [


### PR DESCRIPTION
dub only works properly with lower-case package names.
