### PR TITLE
add importPaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
                 "Jude \"1100110\" Young"
         ],
         "license": "LGPL v3",
+        "importPaths": [
+                "."
+        ],
         "sourcePaths": [
                 "deimos"
         ],


### PR DESCRIPTION
on Sönke's advice. I believe it is so the package path works from deimos instead of deimos.zmq, if that makes sense.
