### PR TITLE
Fix #12: examples do not compile

### DIFF
--- a/examples/hwclient.d
+++ b/examples/hwclient.d
@@ -28,12 +28,12 @@ void main()
         (zmq_msg_data(&request))[0..5] = source[0..5];
 
         writefln("Client: Sending Hello %d...", request_nbr);
-        zmq_send(requester, &request, 0);
+        zmq_sendmsg(requester, &request, 0);
         zmq_msg_close(&request);
 
         zmq_msg_t reply;
         zmq_msg_init(&reply);
-        zmq_recv(requester, &reply, 0);
+        zmq_recvmsg(requester, &reply, 0);
         writefln("Client: Received World %d", request_nbr);
         zmq_msg_close(&reply);
     }

--- a/examples/hwserver.d
+++ b/examples/hwserver.d
@@ -20,7 +20,7 @@ void main()
         ///  Wait for next request from client
         zmq_msg_t request;
         zmq_msg_init(&request);
-        zmq_recv(responder, &request, 0);
+        zmq_recvmsg(responder, &request, 0);
 
         writeln("Server: Recieved Hello");
         zmq_msg_close(&request);
@@ -34,7 +34,7 @@ void main()
         ///Slicing calls memcpy internally.
         immutable(void*) source = "World".ptr;
         (zmq_msg_data(&reply))[0..5] = source[0..5];
-        zmq_send(responder, &reply, 0);
+        zmq_sendmsg(responder, &reply, 0);
         zmq_msg_close(&reply);
     }
     ///  We never get here but if we did, this would be how we end


### PR DESCRIPTION
Examples were using zmq_send instead of zmq_sendmsg
