### PR TITLE
Size of zmq_msg_t size changed.

### DIFF
--- a/C/zmq.h
+++ b/C/zmq.h
@@ -199,7 +199,7 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-typedef struct zmq_msg_t {unsigned char _ [32];} zmq_msg_t;
+typedef struct zmq_msg_t {unsigned char _ [48];} zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -130,7 +130,7 @@ int zmq_ctx_destroy(void* context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-struct zmq_msg_t { ubyte[32] _; }
+struct zmq_msg_t { ubyte[48] _; }
 
 int zmq_msg_init(zmq_msg_t* msg);
 int zmq_msg_init_size(zmq_msg_t* msg, size_t size);


### PR DESCRIPTION
The size of the zmq_msg_t struct was changed in zeromq
https://github.com/zeromq/libzmq/commit/724b2bb84479836343c9f885ec301f2634197035
