### PR TITLE
Undo pull request #16

### DIFF
--- a/C/zmq.h
+++ b/C/zmq.h
@@ -199,7 +199,7 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-typedef struct zmq_msg_t {unsigned char _ [48];} zmq_msg_t;
+typedef struct zmq_msg_t {unsigned char _ [32];} zmq_msg_t;
 
 typedef void (zmq_free_fn) (void *data, void *hint);
 

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -130,7 +130,7 @@ int zmq_ctx_destroy(void* context);
 /*  0MQ message definition.                                                   */
 /******************************************************************************/
 
-struct zmq_msg_t { ubyte[48] _; }
+struct zmq_msg_t { ubyte[32] _; }
 
 int zmq_msg_init(zmq_msg_t* msg);
 int zmq_msg_init_size(zmq_msg_t* msg, size_t size);


### PR DESCRIPTION
Pull request #16 should not have been merged, as it only updated a miniscule part of the ZeroMQ API and left the rest unchanged and inconsistent. Prior to this change, this repository contained headers and bindings for ZeroMQ 4.0.5, which is the latest _stable_ release of ZeroMQ. (Note the version numbers on [line 35 in zmq.d](https://github.com/D-Programming-Deimos/ZeroMQ/blob/master/deimos/zmq/zmq.d#L35).) In this version, the size of `zmq_msg_t` is 32 bytes.

The size of `zmq_msg_t` changed to 48 bytes in ZeroMQ 4.1, which currently has "release candidate" status. Personally, I don't think deimos.zmq needs to support a non-stable ZeroMQ version, but if it does, then it should be done properly. The whole 4.1 C headers should be copied, and the entire D binding should be updated correspondingly.
