### PR TITLE
Remove global @nogc attribute again

### DIFF
--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -28,7 +28,7 @@ module deimos.zmq.zmq;
 
 import core.stdc.config;
 
-nothrow @nogc extern (C)
+nothrow extern (C)
 {
 
 /*  Version macros for compile-time API version detection                     */


### PR DESCRIPTION
I added it in my previous pull request, but now I regret it.

While ZeroMQ itself doesn't use D's garbage collector, some functions take callback functions that may do so.  `zmq_msg_init_data()` is the joker here: It initialises a message with a user-supplied buffer, and stores a pointer to a callback function that will free the buffer when it is done with it.

The problem is that there is generally no easy way to tell when this happens. It could of course be when the message is closed, sent or overwritten, but in principle, ZeroMQ is free to hold on to this buffer for as long as the program is running.  In other words, almost *any* function can in theory trigger the GC.

Therefore, to be safe, no functions should be annotated with `@nogc`.