### PR TITLE
Update to 4.1.4

### DIFF
--- a/C/zmq.h
+++ b/C/zmq.h
@@ -31,7 +31,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 1
-#define ZMQ_VERSION_PATCH 2
+#define ZMQ_VERSION_PATCH 3
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -31,7 +31,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 1
-#define ZMQ_VERSION_PATCH 3
+#define ZMQ_VERSION_PATCH 4
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -36,7 +36,7 @@ enum
 {
     ZMQ_VERSION_MAJOR   = 4,
     ZMQ_VERSION_MINOR   = 1,
-    ZMQ_VERSION_PATCH   = 3
+    ZMQ_VERSION_PATCH   = 4
 }
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -36,7 +36,7 @@ enum
 {
     ZMQ_VERSION_MAJOR   = 4,
     ZMQ_VERSION_MINOR   = 1,
-    ZMQ_VERSION_PATCH   = 2
+    ZMQ_VERSION_PATCH   = 3
 }
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)


### PR DESCRIPTION
As there have been no API changes to ZeroMQ in the past couple of releases, this is a trivial update – just a change of version number. It is mainly to demonstrate that these bindings are actively maintained and kept up to date.

I'll push the corresponding version number tags as soon as this is merged.