### PR TITLE
Update to ZeroMQ 4.2.2

### DIFF
--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 1
+#define ZMQ_VERSION_PATCH 2
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 0
+#define ZMQ_VERSION_PATCH 1
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))
@@ -110,6 +110,13 @@ extern "C" {
 #   endif
 #else
 #   include <stdint.h>
+#endif
+
+//  32-bit AIX's pollfd struct members are called reqevents and rtnevents so it
+//  defines compatibility macros for them. Need to include that header first to
+//  stop build failures since zmq_pollset_t defines them as events and revents.
+#ifdef ZMQ_HAVE_AIX
+    #include <poll.h>
 #endif
 
 
@@ -361,8 +368,6 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
-//  All options after this is for version 4.3 and still *draft*
-//  Subject to arbitrary change without notice
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -555,6 +560,13 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_GATHER 16
 #define ZMQ_SCATTER 17
 #define ZMQ_DGRAM 18
+
+/*  DRAFT 0MQ socket events and monitoring                                    */
+#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
+#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+
+/*  DRAFT Context options                                                     */
+#define ZMQ_MSG_T_SIZE 6
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -46,7 +46,7 @@ enum
 {
     ZMQ_VERSION_MAJOR   = 4,
     ZMQ_VERSION_MINOR   = 2,
-    ZMQ_VERSION_PATCH   = 0
+    ZMQ_VERSION_PATCH   = 1
 }
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)
@@ -499,6 +499,19 @@ enum
     ZMQ_GATHER  = 16,
     ZMQ_SCATTER = 17,
     ZMQ_DGRAM   = 18,
+}
+
+/*  DRAFT 0MQ socket events and monitoring                                    */
+enum
+{
+    ZMQ_EVENT_HANDSHAKE_FAILED  = 0x0800,
+    ZMQ_EVENT_HANDSHAKE_SUCCEED = 0x1000,
+}
+
+/*  DRAFT Context options                                                     */
+enum
+{
+    ZMQ_MSG_T_SIZE = 6,
 }
 
 /*  DRAFT Socket methods.                                                     */

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -46,7 +46,7 @@ enum
 {
     ZMQ_VERSION_MAJOR   = 4,
     ZMQ_VERSION_MINOR   = 2,
-    ZMQ_VERSION_PATCH   = 1
+    ZMQ_VERSION_PATCH   = 2
 }
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -267,7 +267,7 @@ enum
     ZMQ_XPUB_VERBOSER           = 78,
     ZMQ_CONNECT_TIMOUT          = 79,
     ZMQ_TCP_MAXRT               = 80,
-    ZMQ_THREAT_SAFE             = 81,
+    ZMQ_THREAD_SAFE             = 81,
     ZMQ_MULTICAST_MAXTPDU       = 84,
     ZMQ_VMCI_BUFFER_SIZE        = 85,
     ZMQ_VMCI_BUFFER_MIN_SIZE    = 86,
@@ -321,7 +321,8 @@ enum
 }
 
 /* Deprecated Message options                                                 */
-enum {
+enum
+{
     ZMQ_SRCFD = 2,
 }
 
@@ -382,7 +383,7 @@ enum
 struct zmq_pollitem_t
 {
     void* socket;
-    version (win32)
+    version (Windows)
     {
         SOCKET fd;
     }
@@ -444,14 +445,14 @@ int zmq_curve_keypair(char* z85_public_key, char* z85_secret_key);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-int zmq_curve_public(char* z85_public_key, const(char)* z85_secret_key_);
+int zmq_curve_public(char* z85_public_key, const(char)* z85_secret_key);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
 /******************************************************************************/
 void* zmq_atomic_counter_new();
 void zmq_atomic_counter_set(void* counter, int value);
-int zmq_atmoic_counter_inc(void* counter);
+int zmq_atomic_counter_inc(void* counter);
 int zmq_atomic_counter_dec(void* counter);
 int zmq_atomic_counter_value(void* counter);
 void zmq_atomic_counter_destroy(void** counter_p);
@@ -489,7 +490,8 @@ void zmq_threadclose(void* thread);
 version(ZMQ_BUILD_DRAFT_API)
 {
 /*  DRAFT Socket types.                                                       */
-enum {
+enum
+{
     ZMQ_SERVER  = 12,
     ZMQ_CLIENT  = 13,
     ZMQ_RADIO   = 14,
@@ -516,7 +518,7 @@ const(char)* zmq_msg_group(zmq_msg_t* msg);
 struct zmq_poller_event_t
 {
     void* socket;
-    version(win32)
+    version(Windows)
     {
         SOCKET fd;
     }
@@ -536,9 +538,9 @@ int  zmq_poller_remove(void* poller, void* socket);
 int  zmq_poller_wait(void* poller, zmq_poller_event_t* event, c_long timeout);
 int  zmq_poller_wait_all(void* poller, zmq_poller_event_t* events, int n_events, c_long timout);
 
-version (win32)
+version (Windows)
 {
-    int zmq_poller_add_fd(void* poller, SOCKET fd, void* user_data, short_events);
+    int zmq_poller_add_fd(void* poller, SOCKET fd, void* user_data, short events);
     int zmq_poller_modify_fd(void* poller, SOCKET fd, short events);
     int zmq_poller_remove_fd(void* poller, SOCKET fd);
 }


### PR DESCRIPTION
This fixes some typos and unconventional formatting from PR 25, and updates the bindings so they match the ZeroMQ v4.2.2 headers (going via 4.2.1 so I can tag each release properly afterwards).