### PR TITLE
Remove AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,0 @@
-itiu  https://github.com/itiu
-Jude "1100110" Young 10equals2@gmail.com
-
-I'm honestly not sure how much is itiu's code,
-I should have kept track, but I didn't.
-I definitely used his work as a reference, so he should get entire credit.
-	-Jude


### PR DESCRIPTION
Git already keeps track of all contributors, so there's no need to maintain a separate file for it. It was completely out of date too.