### PR TITLE
Update to ZeroMQ 4.3.2

### DIFF
--- a/C/AUTHORS
+++ b/C/AUTHORS
@@ -71,6 +71,7 @@ Ken Steele
 Kouhei Sutou
 Laurent Alebarde
 Leonardo J. Consoni
+Lionel Flandrin
 Lourens Naudé
 Luca Boccassi
 Marc Rossi

--- a/C/AUTHORS
+++ b/C/AUTHORS
@@ -8,6 +8,7 @@ Copyright (c) 2011 VMware, Inc.
 Copyright (c) 2012 Spotify AB
 Copyright (c) 2013 Ericsson AB
 Copyright (c) 2014 AppDynamics Inc.
+Copyright (c) 2015 Google, Inc.
 Copyright (c) 2015-2016 Brocade Communications Systems Inc.
 
 Individual Contributors
@@ -55,6 +56,7 @@ Gerard Toonstra
 Ghislain Putois
 Gonzalo Diethelm
 Guido Goldstein
+Harald Achitz
 Hardeep Singh
 Hiten Pandya
 Ian Barber
@@ -98,6 +100,7 @@ Peter Bourgon
 Philip Kovacs
 Pieter Hintjens
 Piotr Trojanek
+Reza Ebrahimi
 Richard Newton
 Rik van der Heijden
 Robert G. Jakabosky

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 3
-#define ZMQ_VERSION_PATCH 0
+#define ZMQ_VERSION_PATCH 1
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 4
+#define ZMQ_VERSION_PATCH 5
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 3
-#define ZMQ_VERSION_PATCH 1
+#define ZMQ_VERSION_PATCH 2
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))
@@ -98,6 +98,9 @@ extern "C" {
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
 #include <inttypes.h>
 #elif defined _MSC_VER && _MSC_VER < 1600
+#ifndef uint64_t
+typedef unsigned __int64 uint64_t;
+#endif
 #ifndef int32_t
 typedef __int32 int32_t;
 #endif
@@ -652,6 +655,11 @@ ZMQ_EXPORT void zmq_threadclose (void *thread_);
 #define ZMQ_METADATA 95
 #define ZMQ_MULTICAST_LOOP 96
 #define ZMQ_ROUTER_NOTIFY 97
+#define ZMQ_XPUB_MANUAL_LAST_VALUE 98
+#define ZMQ_SOCKS_USERNAME 99
+#define ZMQ_SOCKS_PASSWORD 100
+#define ZMQ_IN_BATCH_SIZE 101
+#define ZMQ_OUT_BATCH_SIZE 102
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_ZERO_COPY_RECV 10
@@ -682,14 +690,16 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 
 #define ZMQ_HAVE_POLLER
 
+#if defined _WIN32
+typedef SOCKET zmq_fd_t;
+#else
+typedef int zmq_fd_t;
+#endif
+
 typedef struct zmq_poller_event_t
 {
     void *socket;
-#if defined _WIN32
-    SOCKET fd;
-#else
-    int fd;
-#endif
+    zmq_fd_t fd;
     void *user_data;
     short events;
 } zmq_poller_event_t;
@@ -706,22 +716,29 @@ ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
                                     zmq_poller_event_t *events,
                                     int n_events,
                                     long timeout);
+ZMQ_EXPORT int zmq_poller_fd (void *poller, zmq_fd_t *fd);
 
-#if defined _WIN32
 ZMQ_EXPORT int
-zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
-#else
-ZMQ_EXPORT int
-zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
-ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
-ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
-#endif
+zmq_poller_add_fd (void *poller, zmq_fd_t fd, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, zmq_fd_t fd, short events);
+ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, zmq_fd_t fd);
 
 ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
                                           const void *routing_id,
                                           size_t routing_id_size);
+
+/*  DRAFT Socket monitoring events                                            */
+#define ZMQ_EVENT_PIPES_STATS 0x10000
+
+#define ZMQ_CURRENT_EVENT_VERSION 1
+#define ZMQ_CURRENT_EVENT_VERSION_DRAFT 2
+
+#define ZMQ_EVENT_ALL_V1 ZMQ_EVENT_ALL
+#define ZMQ_EVENT_ALL_V2 ZMQ_EVENT_ALL_V1 | ZMQ_EVENT_PIPES_STATS
+
+ZMQ_EXPORT int zmq_socket_monitor_versioned (
+  void *s_, const char *addr_, uint64_t events_, int event_version_, int type_);
+ZMQ_EXPORT int zmq_socket_monitor_pipes_stats (void *s);
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,7 +41,7 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 2
+#define ZMQ_VERSION_PATCH 3
 
 #define ZMQ_MAKE_VERSION(major, minor, patch) \
     ((major) * 10000 + (minor) * 100 + (patch))
@@ -66,10 +66,9 @@ extern "C" {
 
 #ifdef __MINGW32__
 //  Require Windows XP or higher with MinGW for getaddrinfo().
-#if(_WIN32_WINNT >= 0x0600)
+#if(_WIN32_WINNT >= 0x0501)
 #else
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#error You need at least Windows XP target
 #endif
 #endif
 #include <winsock2.h>
@@ -101,6 +100,9 @@ extern "C" {
 #elif defined _MSC_VER && _MSC_VER < 1600
 #   ifndef int32_t
         typedef __int32 int32_t;
+#   endif
+#   ifndef uint32_t
+        typedef unsigned __int32 uint32_t;
 #   endif
 #   ifndef uint16_t
         typedef unsigned __int16 uint16_t;
@@ -266,11 +268,11 @@ ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
 ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg);
-ZMQ_EXPORT size_t zmq_msg_size (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_more (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_get (zmq_msg_t *msg, int property);
+ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg, int property);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
-ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
+ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -296,7 +298,7 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 
 /*  Socket options.                                                           */
 #define ZMQ_AFFINITY 4
-#define ZMQ_IDENTITY 5
+#define ZMQ_ROUTING_ID 5
 #define ZMQ_SUBSCRIBE 6
 #define ZMQ_UNSUBSCRIBE 7
 #define ZMQ_RATE 8
@@ -342,7 +344,7 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_ZAP_DOMAIN 55
 #define ZMQ_ROUTER_HANDOVER 56
 #define ZMQ_TOS 57
-#define ZMQ_CONNECT_RID 61
+#define ZMQ_CONNECT_ROUTING_ID 61
 #define ZMQ_GSSAPI_SERVER 62
 #define ZMQ_GSSAPI_PRINCIPAL 63
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL 64
@@ -387,6 +389,8 @@ ZMQ_EXPORT const char *zmq_msg_gets (zmq_msg_t *msg, const char *property);
 #define ZMQ_GROUP_MAX_LENGTH        15
 
 /*  Deprecated options and aliases                                            */
+#define ZMQ_IDENTITY                ZMQ_ROUTING_ID
+#define ZMQ_CONNECT_RID             ZMQ_CONNECT_ROUTING_ID
 #define ZMQ_TCP_ACCEPT_FILTER       38
 #define ZMQ_IPC_FILTER_PID          58
 #define ZMQ_IPC_FILTER_UID          59
@@ -436,7 +440,7 @@ ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
 
 
 /******************************************************************************/
-/*  I/O multiplexing.                                                         */
+/*  Deprecated I/O multiplexing. Prefer using zmq_poller API                  */
 /******************************************************************************/
 
 #define ZMQ_POLLIN 1
@@ -561,12 +565,54 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_SCATTER 17
 #define ZMQ_DGRAM 18
 
+/*  DRAFT Socket options.                                                     */
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+#define ZMQ_BINDTODEVICE 92
+#define ZMQ_ZAP_ENFORCE_DOMAIN 93
+
 /*  DRAFT 0MQ socket events and monitoring                                    */
-#define ZMQ_EVENT_HANDSHAKE_FAILED  0x0800
-#define ZMQ_EVENT_HANDSHAKE_SUCCEED 0x1000
+/*  Unspecified system errors during handshake. Event value is an errno.      */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL   0x0800
+/*  Handshake complete successfully with successful authentication (if        *
+ *  enabled). Event value is unused.                                          */
+#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED          0x1000
+/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
+ *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL    0x2000
+/*  Failed authentication requests. Event value is the numeric ZAP status     *
+ *  code, i.e. 300, 400 or 500.                                               */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH        0x4000
+
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
+#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
+
+// the following two may be due to erroneous configuration of a peer
+#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
+
+#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED     0x20000000
+#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
 /*  DRAFT Context options                                                     */
 #define ZMQ_MSG_T_SIZE 6
+#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
+#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
+#define ZMQ_THREAD_NAME_PREFIX 9
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);
@@ -577,6 +623,12 @@ ZMQ_EXPORT int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id);
 ZMQ_EXPORT uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_set_group(zmq_msg_t *msg, const char *group);
 ZMQ_EXPORT const char *zmq_msg_group(zmq_msg_t *msg);
+
+/*  DRAFT Msg property names.                                                 */
+#define ZMQ_MSG_PROPERTY_ROUTING_ID    "Routing-Id"
+#define ZMQ_MSG_PROPERTY_SOCKET_TYPE   "Socket-Type"
+#define ZMQ_MSG_PROPERTY_USER_ID       "User-Id"
+#define ZMQ_MSG_PROPERTY_PEER_ADDRESS  "Peer-Address"
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
@@ -614,6 +666,10 @@ ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
 ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
 #endif
 
+ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
+                                          const void *routing_id,
+                                          size_t routing_id_size);
+
 /******************************************************************************/
 /*  Scheduling timers                                                         */
 /******************************************************************************/
@@ -630,6 +686,15 @@ ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t int
 ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
 ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
 ZMQ_EXPORT int   zmq_timers_execute (void *timers);
+
+/******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -41,12 +41,12 @@
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
 #define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 3
+#define ZMQ_VERSION_PATCH 4
 
-#define ZMQ_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define ZMQ_VERSION \
-    ZMQ_MAKE_VERSION(ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
+#define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
+    ((major) *10000 + (minor) *100 + (patch))
+#define ZMQ_VERSION                                                            \
+    ZMQ_MAKE_VERSION (ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,7 +66,7 @@ extern "C" {
 
 #ifdef __MINGW32__
 //  Require Windows XP or higher with MinGW for getaddrinfo().
-#if(_WIN32_WINNT >= 0x0501)
+#if (_WIN32_WINNT >= 0x0501)
 #else
 #error You need at least Windows XP target
 #endif
@@ -76,49 +76,49 @@ extern "C" {
 
 /*  Handle DSO symbol visibility                                             */
 #if defined _WIN32
-#   if defined ZMQ_STATIC
-#       define ZMQ_EXPORT
-#   elif defined DLL_EXPORT
-#       define ZMQ_EXPORT __declspec(dllexport)
-#   else
-#       define ZMQ_EXPORT __declspec(dllimport)
-#   endif
+#if defined ZMQ_STATIC
+#define ZMQ_EXPORT
+#elif defined DLL_EXPORT
+#define ZMQ_EXPORT __declspec(dllexport)
 #else
-#   if defined __SUNPRO_C  || defined __SUNPRO_CC
-#       define ZMQ_EXPORT __global
-#   elif (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
-#       define ZMQ_EXPORT __attribute__ ((visibility("default")))
-#   else
-#       define ZMQ_EXPORT
-#   endif
+#define ZMQ_EXPORT __declspec(dllimport)
+#endif
+#else
+#if defined __SUNPRO_C || defined __SUNPRO_CC
+#define ZMQ_EXPORT __global
+#elif (defined __GNUC__ && __GNUC__ >= 4) || defined __INTEL_COMPILER
+#define ZMQ_EXPORT __attribute__ ((visibility ("default")))
+#else
+#define ZMQ_EXPORT
+#endif
 #endif
 
 /*  Define integer types needed for event interface                          */
 #define ZMQ_DEFINED_STDINT 1
 #if defined ZMQ_HAVE_SOLARIS || defined ZMQ_HAVE_OPENVMS
-#   include <inttypes.h>
+#include <inttypes.h>
 #elif defined _MSC_VER && _MSC_VER < 1600
-#   ifndef int32_t
-        typedef __int32 int32_t;
-#   endif
-#   ifndef uint32_t
-        typedef unsigned __int32 uint32_t;
-#   endif
-#   ifndef uint16_t
-        typedef unsigned __int16 uint16_t;
-#   endif
-#   ifndef uint8_t
-        typedef unsigned __int8 uint8_t;
-#   endif
+#ifndef int32_t
+typedef __int32 int32_t;
+#endif
+#ifndef uint32_t
+typedef unsigned __int32 uint32_t;
+#endif
+#ifndef uint16_t
+typedef unsigned __int16 uint16_t;
+#endif
+#ifndef uint8_t
+typedef unsigned __int8 uint8_t;
+#endif
 #else
-#   include <stdint.h>
+#include <stdint.h>
 #endif
 
 //  32-bit AIX's pollfd struct members are called reqevents and rtnevents so it
 //  defines compatibility macros for them. Need to include that header first to
 //  stop build failures since zmq_pollset_t defines them as events and revents.
 #ifdef ZMQ_HAVE_AIX
-    #include <poll.h>
+#include <poll.h>
 #endif
 
 
@@ -209,7 +209,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 /******************************************************************************/
 
 /*  Context options                                                           */
-#define ZMQ_IO_THREADS  1
+#define ZMQ_IO_THREADS 1
 #define ZMQ_MAX_SOCKETS 2
 #define ZMQ_SOCKET_LIMIT 3
 #define ZMQ_THREAD_PRIORITY 3
@@ -217,7 +217,7 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_MAX_MSGSZ 5
 
 /*  Default for new contexts                                                  */
-#define ZMQ_IO_THREADS_DFLT  1
+#define ZMQ_IO_THREADS_DFLT 1
 #define ZMQ_MAX_SOCKETS_DFLT 1023
 #define ZMQ_THREAD_PRIORITY_DFLT -1
 #define ZMQ_THREAD_SCHED_POLICY_DFLT -1
@@ -242,26 +242,27 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
  * alignment and raise sigbus on violations. Make sure applications allocate
  * zmq_msg_t on addresses aligned on a pointer-size boundary to avoid this issue.
  */
-typedef struct zmq_msg_t {
-#if defined (__GNUC__) || defined ( __INTEL_COMPILER) || \
-        (defined (__SUNPRO_C) && __SUNPRO_C >= 0x590) || \
-        (defined (__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
-    unsigned char _ [64] __attribute__ ((aligned (sizeof (void *))));
-#elif defined (_MSC_VER) && (defined (_M_X64) || defined (_M_ARM64))
-    __declspec (align (8)) unsigned char _ [64];
-#elif defined (_MSC_VER) && (defined (_M_IX86) || defined (_M_ARM_ARMV7VE))
-    __declspec (align (4)) unsigned char _ [64];
+typedef struct zmq_msg_t
+{
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_ARM64))
+    __declspec(align (8)) unsigned char _[64];
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_ARM_ARMV7VE))
+    __declspec(align (4)) unsigned char _[64];
+#elif defined(__GNUC__) || defined(__INTEL_COMPILER)                           \
+  || (defined(__SUNPRO_C) && __SUNPRO_C >= 0x590)                              \
+  || (defined(__SUNPRO_CC) && __SUNPRO_CC >= 0x590)
+    unsigned char _[64] __attribute__ ((aligned (sizeof (void *))));
 #else
-    unsigned char _ [64];
+    unsigned char _[64];
 #endif
 } zmq_msg_t;
 
-typedef void (zmq_free_fn) (void *data, void *hint);
+typedef void(zmq_free_fn) (void *data, void *hint);
 
 ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg, size_t size);
-ZMQ_EXPORT int zmq_msg_init_data (zmq_msg_t *msg, void *data,
-    size_t size, zmq_free_fn *ffn, void *hint);
+ZMQ_EXPORT int zmq_msg_init_data (
+  zmq_msg_t *msg, void *data, size_t size, zmq_free_fn *ffn, void *hint);
 ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg, void *s, int flags);
 ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg, void *s, int flags);
 ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
@@ -272,7 +273,8 @@ ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg);
 ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg, int property);
 ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
-ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property);
+ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
+                                     const char *property);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -386,20 +388,20 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property)
 #define ZMQ_GSSAPI 3
 
 /*  RADIO-DISH protocol                                                       */
-#define ZMQ_GROUP_MAX_LENGTH        15
+#define ZMQ_GROUP_MAX_LENGTH 15
 
 /*  Deprecated options and aliases                                            */
-#define ZMQ_IDENTITY                ZMQ_ROUTING_ID
-#define ZMQ_CONNECT_RID             ZMQ_CONNECT_ROUTING_ID
-#define ZMQ_TCP_ACCEPT_FILTER       38
-#define ZMQ_IPC_FILTER_PID          58
-#define ZMQ_IPC_FILTER_UID          59
-#define ZMQ_IPC_FILTER_GID          60
-#define ZMQ_IPV4ONLY                31
+#define ZMQ_IDENTITY ZMQ_ROUTING_ID
+#define ZMQ_CONNECT_RID ZMQ_CONNECT_ROUTING_ID
+#define ZMQ_TCP_ACCEPT_FILTER 38
+#define ZMQ_IPC_FILTER_PID 58
+#define ZMQ_IPC_FILTER_UID 59
+#define ZMQ_IPC_FILTER_GID 60
+#define ZMQ_IPV4ONLY 31
 #define ZMQ_DELAY_ATTACH_ON_CONNECT ZMQ_IMMEDIATE
-#define ZMQ_NOBLOCK                 ZMQ_DONTWAIT
-#define ZMQ_FAIL_UNROUTABLE         ZMQ_ROUTER_MANDATORY
-#define ZMQ_ROUTER_BEHAVIOR         ZMQ_ROUTER_MANDATORY
+#define ZMQ_NOBLOCK ZMQ_DONTWAIT
+#define ZMQ_FAIL_UNROUTABLE ZMQ_ROUTER_MANDATORY
+#define ZMQ_ROUTER_BEHAVIOR ZMQ_ROUTER_MANDATORY
 
 /*  Deprecated Message options                                                */
 #define ZMQ_SRCFD 2
@@ -410,25 +412,25 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg, const char *property)
 
 /*  Socket transport events (TCP, IPC and TIPC only)                          */
 
-#define ZMQ_EVENT_CONNECTED         0x0001
-#define ZMQ_EVENT_CONNECT_DELAYED   0x0002
-#define ZMQ_EVENT_CONNECT_RETRIED   0x0004
-#define ZMQ_EVENT_LISTENING         0x0008
-#define ZMQ_EVENT_BIND_FAILED       0x0010
-#define ZMQ_EVENT_ACCEPTED          0x0020
-#define ZMQ_EVENT_ACCEPT_FAILED     0x0040
-#define ZMQ_EVENT_CLOSED            0x0080
-#define ZMQ_EVENT_CLOSE_FAILED      0x0100
-#define ZMQ_EVENT_DISCONNECTED      0x0200
-#define ZMQ_EVENT_MONITOR_STOPPED   0x0400
-#define ZMQ_EVENT_ALL               0xFFFF
+#define ZMQ_EVENT_CONNECTED 0x0001
+#define ZMQ_EVENT_CONNECT_DELAYED 0x0002
+#define ZMQ_EVENT_CONNECT_RETRIED 0x0004
+#define ZMQ_EVENT_LISTENING 0x0008
+#define ZMQ_EVENT_BIND_FAILED 0x0010
+#define ZMQ_EVENT_ACCEPTED 0x0020
+#define ZMQ_EVENT_ACCEPT_FAILED 0x0040
+#define ZMQ_EVENT_CLOSED 0x0080
+#define ZMQ_EVENT_CLOSE_FAILED 0x0100
+#define ZMQ_EVENT_DISCONNECTED 0x0200
+#define ZMQ_EVENT_MONITOR_STOPPED 0x0400
+#define ZMQ_EVENT_ALL 0xFFFF
 
 ZMQ_EXPORT void *zmq_socket (void *, int type);
 ZMQ_EXPORT int zmq_close (void *s);
-ZMQ_EXPORT int zmq_setsockopt (void *s, int option, const void *optval,
-    size_t optvallen);
-ZMQ_EXPORT int zmq_getsockopt (void *s, int option, void *optval,
-    size_t *optvallen);
+ZMQ_EXPORT int
+zmq_setsockopt (void *s, int option, const void *optval, size_t optvallen);
+ZMQ_EXPORT int
+zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
 ZMQ_EXPORT int zmq_bind (void *s, const char *addr);
 ZMQ_EXPORT int zmq_connect (void *s, const char *addr);
 ZMQ_EXPORT int zmq_unbind (void *s, const char *addr);
@@ -462,14 +464,17 @@ typedef struct zmq_pollitem_t
 
 #define ZMQ_POLLITEMS_DFLT 16
 
-ZMQ_EXPORT int  zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
+ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 
 /******************************************************************************/
 /*  Message proxying                                                          */
 /******************************************************************************/
 
 ZMQ_EXPORT int zmq_proxy (void *frontend, void *backend, void *capture);
-ZMQ_EXPORT int zmq_proxy_steerable (void *frontend, void *backend, void *capture, void *control);
+ZMQ_EXPORT int zmq_proxy_steerable (void *frontend,
+                                    void *backend,
+                                    void *capture,
+                                    void *control);
 
 /******************************************************************************/
 /*  Probe library capabilities                                                */
@@ -488,8 +493,10 @@ ZMQ_EXPORT int zmq_device (int type, void *frontend, void *backend);
 ZMQ_EXPORT int zmq_sendmsg (void *s, zmq_msg_t *msg, int flags);
 ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
 struct iovec;
-ZMQ_EXPORT int zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
-ZMQ_EXPORT int zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
+ZMQ_EXPORT int
+zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
+ZMQ_EXPORT int
+zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
 
 /******************************************************************************/
 /*  Encryption functions                                                      */
@@ -507,7 +514,8 @@ ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-ZMQ_EXPORT int zmq_curve_public (char *z85_public_key, const char *z85_secret_key);
+ZMQ_EXPORT int zmq_curve_public (char *z85_public_key,
+                                 const char *z85_secret_key);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
@@ -533,20 +541,26 @@ ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 ZMQ_EXPORT void *zmq_stopwatch_start (void);
 
+#ifdef ZMQ_BUILD_DRAFT_API
+/*  Returns the number of microseconds elapsed since the stopwatch was        */
+/*  started, but does not stop or deallocate the stopwatch.                   */
+ZMQ_EXPORT unsigned long zmq_stopwatch_intermediate (void *watch_);
+#endif
+
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
-/*  the stopwatch was started.                                                */
+/*  the stopwatch was started, and deallocates that watch.                    */
 ZMQ_EXPORT unsigned long zmq_stopwatch_stop (void *watch_);
 
 /*  Sleeps for specified number of seconds.                                   */
 ZMQ_EXPORT void zmq_sleep (int seconds_);
 
-typedef void (zmq_thread_fn) (void*);
+typedef void(zmq_thread_fn) (void *);
 
 /* Start a thread. Returns a handle to the thread.                            */
-ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn* func, void* arg);
+ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn *func, void *arg);
 
 /* Wait for thread to complete then free up resources.                        */
-ZMQ_EXPORT void zmq_threadclose (void* thread);
+ZMQ_EXPORT void zmq_threadclose (void *thread);
 
 
 /******************************************************************************/
@@ -570,19 +584,21 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
 #define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
+#define ZMQ_LOOPBACK_FASTPATH 94
+#define ZMQ_METADATA 95
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
 /*  Unspecified system errors during handshake. Event value is an errno.      */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL   0x0800
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
 /*  Handshake complete successfully with successful authentication (if        *
  *  enabled). Event value is unused.                                          */
-#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED          0x1000
+#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
 /*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
  *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL    0x2000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
 /*  Failed authentication requests. Event value is the numeric ZAP status     *
  *  code, i.e. 300, 400 or 500.                                               */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH        0x4000
+#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
 
 #define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
 #define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
@@ -601,7 +617,7 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
 #define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
 
-#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED     0x20000000
+#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
 #define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
 #define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
 #define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
@@ -613,22 +629,23 @@ ZMQ_EXPORT void zmq_threadclose (void* thread);
 #define ZMQ_THREAD_AFFINITY_CPU_ADD 7
 #define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
 #define ZMQ_THREAD_NAME_PREFIX 9
+#define ZMQ_ZERO_COPY_RECV 10
 
 /*  DRAFT Socket methods.                                                     */
 ZMQ_EXPORT int zmq_join (void *s, const char *group);
 ZMQ_EXPORT int zmq_leave (void *s, const char *group);
 
 /*  DRAFT Msg methods.                                                        */
-ZMQ_EXPORT int zmq_msg_set_routing_id(zmq_msg_t *msg, uint32_t routing_id);
-ZMQ_EXPORT uint32_t zmq_msg_routing_id(zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_set_group(zmq_msg_t *msg, const char *group);
-ZMQ_EXPORT const char *zmq_msg_group(zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_set_routing_id (zmq_msg_t *msg, uint32_t routing_id);
+ZMQ_EXPORT uint32_t zmq_msg_routing_id (zmq_msg_t *msg);
+ZMQ_EXPORT int zmq_msg_set_group (zmq_msg_t *msg, const char *group);
+ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 
 /*  DRAFT Msg property names.                                                 */
-#define ZMQ_MSG_PROPERTY_ROUTING_ID    "Routing-Id"
-#define ZMQ_MSG_PROPERTY_SOCKET_TYPE   "Socket-Type"
-#define ZMQ_MSG_PROPERTY_USER_ID       "User-Id"
-#define ZMQ_MSG_PROPERTY_PEER_ADDRESS  "Peer-Address"
+#define ZMQ_MSG_PROPERTY_ROUTING_ID "Routing-Id"
+#define ZMQ_MSG_PROPERTY_SOCKET_TYPE "Socket-Type"
+#define ZMQ_MSG_PROPERTY_USER_ID "User-Id"
+#define ZMQ_MSG_PROPERTY_PEER_ADDRESS "Peer-Address"
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
@@ -649,19 +666,26 @@ typedef struct zmq_poller_event_t
 } zmq_poller_event_t;
 
 ZMQ_EXPORT void *zmq_poller_new (void);
-ZMQ_EXPORT int  zmq_poller_destroy (void **poller_p);
-ZMQ_EXPORT int  zmq_poller_add (void *poller, void *socket, void *user_data, short events);
-ZMQ_EXPORT int  zmq_poller_modify (void *poller, void *socket, short events);
-ZMQ_EXPORT int  zmq_poller_remove (void *poller, void *socket);
-ZMQ_EXPORT int  zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
-ZMQ_EXPORT int  zmq_poller_wait_all (void *poller, zmq_poller_event_t *events, int n_events, long timeout);
+ZMQ_EXPORT int zmq_poller_destroy (void **poller_p);
+ZMQ_EXPORT int
+zmq_poller_add (void *poller, void *socket, void *user_data, short events);
+ZMQ_EXPORT int zmq_poller_modify (void *poller, void *socket, short events);
+ZMQ_EXPORT int zmq_poller_remove (void *poller, void *socket);
+ZMQ_EXPORT int
+zmq_poller_wait (void *poller, zmq_poller_event_t *event, long timeout);
+ZMQ_EXPORT int zmq_poller_wait_all (void *poller,
+                                    zmq_poller_event_t *events,
+                                    int n_events,
+                                    long timeout);
 
 #if defined _WIN32
-ZMQ_EXPORT int zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
+ZMQ_EXPORT int
+zmq_poller_add_fd (void *poller, SOCKET fd, void *user_data, short events);
 ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, SOCKET fd, short events);
 ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, SOCKET fd);
 #else
-ZMQ_EXPORT int zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
+ZMQ_EXPORT int
+zmq_poller_add_fd (void *poller, int fd, void *user_data, short events);
 ZMQ_EXPORT int zmq_poller_modify_fd (void *poller, int fd, short events);
 ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
 #endif
@@ -676,16 +700,18 @@ ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
 
 #define ZMQ_HAVE_TIMERS
 
-typedef void (zmq_timer_fn)(int timer_id, void *arg);
+typedef void(zmq_timer_fn) (int timer_id, void *arg);
 
 ZMQ_EXPORT void *zmq_timers_new (void);
-ZMQ_EXPORT int   zmq_timers_destroy (void **timers_p);
-ZMQ_EXPORT int   zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
-ZMQ_EXPORT int   zmq_timers_cancel (void *timers, int timer_id);
-ZMQ_EXPORT int   zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
-ZMQ_EXPORT int   zmq_timers_reset (void *timers, int timer_id);
-ZMQ_EXPORT long  zmq_timers_timeout (void *timers);
-ZMQ_EXPORT int   zmq_timers_execute (void *timers);
+ZMQ_EXPORT int zmq_timers_destroy (void **timers_p);
+ZMQ_EXPORT int
+zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
+ZMQ_EXPORT int zmq_timers_cancel (void *timers, int timer_id);
+ZMQ_EXPORT int
+zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
+ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
+ZMQ_EXPORT long zmq_timers_timeout (void *timers);
+ZMQ_EXPORT int zmq_timers_execute (void *timers);
 
 /******************************************************************************/
 /*  GSSAPI definitions                                                        */

--- a/C/zmq.h
+++ b/C/zmq.h
@@ -40,8 +40,8 @@
 
 /*  Version macros for compile-time API version detection                     */
 #define ZMQ_VERSION_MAJOR 4
-#define ZMQ_VERSION_MINOR 2
-#define ZMQ_VERSION_PATCH 5
+#define ZMQ_VERSION_MINOR 3
+#define ZMQ_VERSION_PATCH 0
 
 #define ZMQ_MAKE_VERSION(major, minor, patch)                                  \
     ((major) *10000 + (minor) *100 + (patch))
@@ -199,10 +199,10 @@ typedef unsigned __int8 uint8_t;
 ZMQ_EXPORT int zmq_errno (void);
 
 /*  Resolves system errors and 0MQ errors to human-readable string.           */
-ZMQ_EXPORT const char *zmq_strerror (int errnum);
+ZMQ_EXPORT const char *zmq_strerror (int errnum_);
 
 /*  Run-time API version detection                                            */
-ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
+ZMQ_EXPORT void zmq_version (int *major_, int *minor_, int *patch_);
 
 /******************************************************************************/
 /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
@@ -215,6 +215,10 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_THREAD_PRIORITY 3
 #define ZMQ_THREAD_SCHED_POLICY 4
 #define ZMQ_MAX_MSGSZ 5
+#define ZMQ_MSG_T_SIZE 6
+#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
+#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
+#define ZMQ_THREAD_NAME_PREFIX 9
 
 /*  Default for new contexts                                                  */
 #define ZMQ_IO_THREADS_DFLT 1
@@ -223,15 +227,15 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ZMQ_THREAD_SCHED_POLICY_DFLT -1
 
 ZMQ_EXPORT void *zmq_ctx_new (void);
-ZMQ_EXPORT int zmq_ctx_term (void *context);
-ZMQ_EXPORT int zmq_ctx_shutdown (void *context);
-ZMQ_EXPORT int zmq_ctx_set (void *context, int option, int optval);
-ZMQ_EXPORT int zmq_ctx_get (void *context, int option);
+ZMQ_EXPORT int zmq_ctx_term (void *context_);
+ZMQ_EXPORT int zmq_ctx_shutdown (void *context_);
+ZMQ_EXPORT int zmq_ctx_set (void *context_, int option_, int optval_);
+ZMQ_EXPORT int zmq_ctx_get (void *context_, int option_);
 
 /*  Old (legacy) API                                                          */
-ZMQ_EXPORT void *zmq_init (int io_threads);
-ZMQ_EXPORT int zmq_term (void *context);
-ZMQ_EXPORT int zmq_ctx_destroy (void *context);
+ZMQ_EXPORT void *zmq_init (int io_threads_);
+ZMQ_EXPORT int zmq_term (void *context_);
+ZMQ_EXPORT int zmq_ctx_destroy (void *context_);
 
 
 /******************************************************************************/
@@ -257,24 +261,24 @@ typedef struct zmq_msg_t
 #endif
 } zmq_msg_t;
 
-typedef void(zmq_free_fn) (void *data, void *hint);
+typedef void(zmq_free_fn) (void *data_, void *hint_);
 
-ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg, size_t size);
+ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg_);
+ZMQ_EXPORT int zmq_msg_init_size (zmq_msg_t *msg_, size_t size_);
 ZMQ_EXPORT int zmq_msg_init_data (
-  zmq_msg_t *msg, void *data, size_t size, zmq_free_fn *ffn, void *hint);
-ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg, void *s, int flags);
-ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg, void *s, int flags);
-ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
-ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
-ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg);
-ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg);
-ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg, int property);
-ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int property, int optval);
-ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
-                                     const char *property);
+  zmq_msg_t *msg_, void *data_, size_t size_, zmq_free_fn *ffn_, void *hint_);
+ZMQ_EXPORT int zmq_msg_send (zmq_msg_t *msg_, void *s_, int flags_);
+ZMQ_EXPORT int zmq_msg_recv (zmq_msg_t *msg_, void *s_, int flags_);
+ZMQ_EXPORT int zmq_msg_close (zmq_msg_t *msg_);
+ZMQ_EXPORT int zmq_msg_move (zmq_msg_t *dest_, zmq_msg_t *src_);
+ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest_, zmq_msg_t *src_);
+ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg_);
+ZMQ_EXPORT size_t zmq_msg_size (const zmq_msg_t *msg_);
+ZMQ_EXPORT int zmq_msg_more (const zmq_msg_t *msg_);
+ZMQ_EXPORT int zmq_msg_get (const zmq_msg_t *msg_, int property_);
+ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg_, int property_, int optval_);
+ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg_,
+                                     const char *property_);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -372,6 +376,9 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_VMCI_BUFFER_MAX_SIZE 87
 #define ZMQ_VMCI_CONNECT_TIMEOUT 88
 #define ZMQ_USE_FD 89
+#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
+#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
+#define ZMQ_BINDTODEVICE 92
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1
@@ -407,6 +414,15 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_SRCFD 2
 
 /******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+#define ZMQ_GSSAPI_NT_HOSTBASED 0
+#define ZMQ_GSSAPI_NT_USER_NAME 1
+#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
+
+/******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
 /******************************************************************************/
 
@@ -424,21 +440,54 @@ ZMQ_EXPORT const char *zmq_msg_gets (const zmq_msg_t *msg,
 #define ZMQ_EVENT_DISCONNECTED 0x0200
 #define ZMQ_EVENT_MONITOR_STOPPED 0x0400
 #define ZMQ_EVENT_ALL 0xFFFF
+/*  Unspecified system errors during handshake. Event value is an errno.      */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
+/*  Handshake complete successfully with successful authentication (if        *
+ *  enabled). Event value is unused.                                          */
+#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
+/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
+ *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
+/*  Failed authentication requests. Event value is the numeric ZAP status     *
+ *  code, i.e. 300, 400 or 500.                                               */
+#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
+#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
+#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
+#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
+// the following two may be due to erroneous configuration of a peer
+#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
+#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
+#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
+#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
+#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
+#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
 
-ZMQ_EXPORT void *zmq_socket (void *, int type);
-ZMQ_EXPORT int zmq_close (void *s);
+ZMQ_EXPORT void *zmq_socket (void *, int type_);
+ZMQ_EXPORT int zmq_close (void *s_);
 ZMQ_EXPORT int
-zmq_setsockopt (void *s, int option, const void *optval, size_t optvallen);
+zmq_setsockopt (void *s_, int option_, const void *optval_, size_t optvallen_);
 ZMQ_EXPORT int
-zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
-ZMQ_EXPORT int zmq_bind (void *s, const char *addr);
-ZMQ_EXPORT int zmq_connect (void *s, const char *addr);
-ZMQ_EXPORT int zmq_unbind (void *s, const char *addr);
-ZMQ_EXPORT int zmq_disconnect (void *s, const char *addr);
-ZMQ_EXPORT int zmq_send (void *s, const void *buf, size_t len, int flags);
-ZMQ_EXPORT int zmq_send_const (void *s, const void *buf, size_t len, int flags);
-ZMQ_EXPORT int zmq_recv (void *s, void *buf, size_t len, int flags);
-ZMQ_EXPORT int zmq_socket_monitor (void *s, const char *addr, int events);
+zmq_getsockopt (void *s_, int option_, void *optval_, size_t *optvallen_);
+ZMQ_EXPORT int zmq_bind (void *s_, const char *addr_);
+ZMQ_EXPORT int zmq_connect (void *s_, const char *addr_);
+ZMQ_EXPORT int zmq_unbind (void *s_, const char *addr_);
+ZMQ_EXPORT int zmq_disconnect (void *s_, const char *addr_);
+ZMQ_EXPORT int zmq_send (void *s_, const void *buf_, size_t len_, int flags_);
+ZMQ_EXPORT int
+zmq_send_const (void *s_, const void *buf_, size_t len_, int flags_);
+ZMQ_EXPORT int zmq_recv (void *s_, void *buf_, size_t len_, int flags_);
+ZMQ_EXPORT int zmq_socket_monitor (void *s_, const char *addr_, int events_);
 
 
 /******************************************************************************/
@@ -464,24 +513,24 @@ typedef struct zmq_pollitem_t
 
 #define ZMQ_POLLITEMS_DFLT 16
 
-ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
+ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items_, int nitems_, long timeout_);
 
 /******************************************************************************/
 /*  Message proxying                                                          */
 /******************************************************************************/
 
-ZMQ_EXPORT int zmq_proxy (void *frontend, void *backend, void *capture);
-ZMQ_EXPORT int zmq_proxy_steerable (void *frontend,
-                                    void *backend,
-                                    void *capture,
-                                    void *control);
+ZMQ_EXPORT int zmq_proxy (void *frontend_, void *backend_, void *capture_);
+ZMQ_EXPORT int zmq_proxy_steerable (void *frontend_,
+                                    void *backend_,
+                                    void *capture_,
+                                    void *control_);
 
 /******************************************************************************/
 /*  Probe library capabilities                                                */
 /******************************************************************************/
 
 #define ZMQ_HAS_CAPABILITIES 1
-ZMQ_EXPORT int zmq_has (const char *capability);
+ZMQ_EXPORT int zmq_has (const char *capability_);
 
 /*  Deprecated aliases */
 #define ZMQ_STREAMER 1
@@ -489,44 +538,64 @@ ZMQ_EXPORT int zmq_has (const char *capability);
 #define ZMQ_QUEUE 3
 
 /*  Deprecated methods */
-ZMQ_EXPORT int zmq_device (int type, void *frontend, void *backend);
-ZMQ_EXPORT int zmq_sendmsg (void *s, zmq_msg_t *msg, int flags);
-ZMQ_EXPORT int zmq_recvmsg (void *s, zmq_msg_t *msg, int flags);
+ZMQ_EXPORT int zmq_device (int type_, void *frontend_, void *backend_);
+ZMQ_EXPORT int zmq_sendmsg (void *s_, zmq_msg_t *msg_, int flags_);
+ZMQ_EXPORT int zmq_recvmsg (void *s_, zmq_msg_t *msg_, int flags_);
 struct iovec;
 ZMQ_EXPORT int
-zmq_sendiov (void *s, struct iovec *iov, size_t count, int flags);
+zmq_sendiov (void *s_, struct iovec *iov_, size_t count_, int flags_);
 ZMQ_EXPORT int
-zmq_recviov (void *s, struct iovec *iov, size_t *count, int flags);
+zmq_recviov (void *s_, struct iovec *iov_, size_t *count_, int flags_);
 
 /******************************************************************************/
 /*  Encryption functions                                                      */
 /******************************************************************************/
 
 /*  Encode data with Z85 encoding. Returns encoded data                       */
-ZMQ_EXPORT char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
+ZMQ_EXPORT char *
+zmq_z85_encode (char *dest_, const uint8_t *data_, size_t size_);
 
 /*  Decode data with Z85 encoding. Returns decoded data                       */
-ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
+ZMQ_EXPORT uint8_t *zmq_z85_decode (uint8_t *dest_, const char *string_);
 
 /*  Generate z85-encoded public and private keypair with tweetnacl/libsodium. */
 /*  Returns 0 on success.                                                     */
-ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key, char *z85_secret_key);
+ZMQ_EXPORT int zmq_curve_keypair (char *z85_public_key_, char *z85_secret_key_);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-ZMQ_EXPORT int zmq_curve_public (char *z85_public_key,
-                                 const char *z85_secret_key);
+ZMQ_EXPORT int zmq_curve_public (char *z85_public_key_,
+                                 const char *z85_secret_key_);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
 /******************************************************************************/
 
 ZMQ_EXPORT void *zmq_atomic_counter_new (void);
-ZMQ_EXPORT void zmq_atomic_counter_set (void *counter, int value);
-ZMQ_EXPORT int zmq_atomic_counter_inc (void *counter);
-ZMQ_EXPORT int zmq_atomic_counter_dec (void *counter);
-ZMQ_EXPORT int zmq_atomic_counter_value (void *counter);
-ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p);
+ZMQ_EXPORT void zmq_atomic_counter_set (void *counter_, int value_);
+ZMQ_EXPORT int zmq_atomic_counter_inc (void *counter_);
+ZMQ_EXPORT int zmq_atomic_counter_dec (void *counter_);
+ZMQ_EXPORT int zmq_atomic_counter_value (void *counter_);
+ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p_);
+
+/******************************************************************************/
+/*  Scheduling timers                                                         */
+/******************************************************************************/
+
+#define ZMQ_HAVE_TIMERS
+
+typedef void(zmq_timer_fn) (int timer_id, void *arg);
+
+ZMQ_EXPORT void *zmq_timers_new (void);
+ZMQ_EXPORT int zmq_timers_destroy (void **timers_p);
+ZMQ_EXPORT int
+zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
+ZMQ_EXPORT int zmq_timers_cancel (void *timers, int timer_id);
+ZMQ_EXPORT int
+zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
+ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
+ZMQ_EXPORT long zmq_timers_timeout (void *timers);
+ZMQ_EXPORT int zmq_timers_execute (void *timers);
 
 
 /******************************************************************************/
@@ -541,11 +610,9 @@ ZMQ_EXPORT void zmq_atomic_counter_destroy (void **counter_p);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 ZMQ_EXPORT void *zmq_stopwatch_start (void);
 
-#ifdef ZMQ_BUILD_DRAFT_API
 /*  Returns the number of microseconds elapsed since the stopwatch was        */
 /*  started, but does not stop or deallocate the stopwatch.                   */
 ZMQ_EXPORT unsigned long zmq_stopwatch_intermediate (void *watch_);
-#endif
 
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
 /*  the stopwatch was started, and deallocates that watch.                    */
@@ -557,10 +624,10 @@ ZMQ_EXPORT void zmq_sleep (int seconds_);
 typedef void(zmq_thread_fn) (void *);
 
 /* Start a thread. Returns a handle to the thread.                            */
-ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn *func, void *arg);
+ZMQ_EXPORT void *zmq_threadstart (zmq_thread_fn *func_, void *arg_);
 
 /* Wait for thread to complete then free up resources.                        */
-ZMQ_EXPORT void zmq_threadclose (void *thread);
+ZMQ_EXPORT void zmq_threadclose (void *thread_);
 
 
 /******************************************************************************/
@@ -580,55 +647,13 @@ ZMQ_EXPORT void zmq_threadclose (void *thread);
 #define ZMQ_DGRAM 18
 
 /*  DRAFT Socket options.                                                     */
-#define ZMQ_GSSAPI_PRINCIPAL_NAMETYPE 90
-#define ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE 91
-#define ZMQ_BINDTODEVICE 92
 #define ZMQ_ZAP_ENFORCE_DOMAIN 93
 #define ZMQ_LOOPBACK_FASTPATH 94
 #define ZMQ_METADATA 95
-
-/*  DRAFT 0MQ socket events and monitoring                                    */
-/*  Unspecified system errors during handshake. Event value is an errno.      */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL 0x0800
-/*  Handshake complete successfully with successful authentication (if        *
- *  enabled). Event value is unused.                                          */
-#define ZMQ_EVENT_HANDSHAKE_SUCCEEDED 0x1000
-/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
- *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL 0x2000
-/*  Failed authentication requests. Event value is the numeric ZAP status     *
- *  code, i.e. 300, 400 or 500.                                               */
-#define ZMQ_EVENT_HANDSHAKE_FAILED_AUTH 0x4000
-
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED 0x10000000
-#define ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND 0x10000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE 0x10000002
-#define ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE 0x10000003
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED 0x10000011
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE 0x10000012
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO 0x10000013
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE 0x10000014
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR 0x10000015
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY 0x10000016
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME 0x10000017
-#define ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA 0x10000018
-
-// the following two may be due to erroneous configuration of a peer
-#define ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC 0x11000001
-#define ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH 0x11000002
-
-#define ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED 0x20000000
-#define ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY 0x20000001
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID 0x20000002
-#define ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION 0x20000003
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE 0x20000004
-#define ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA 0x20000005
+#define ZMQ_MULTICAST_LOOP 96
+#define ZMQ_ROUTER_NOTIFY 97
 
 /*  DRAFT Context options                                                     */
-#define ZMQ_MSG_T_SIZE 6
-#define ZMQ_THREAD_AFFINITY_CPU_ADD 7
-#define ZMQ_THREAD_AFFINITY_CPU_REMOVE 8
-#define ZMQ_THREAD_NAME_PREFIX 9
 #define ZMQ_ZERO_COPY_RECV 10
 
 /*  DRAFT Socket methods.                                                     */
@@ -646,6 +671,10 @@ ZMQ_EXPORT const char *zmq_msg_group (zmq_msg_t *msg);
 #define ZMQ_MSG_PROPERTY_SOCKET_TYPE "Socket-Type"
 #define ZMQ_MSG_PROPERTY_USER_ID "User-Id"
 #define ZMQ_MSG_PROPERTY_PEER_ADDRESS "Peer-Address"
+
+/*  Router notify options                                                     */
+#define ZMQ_NOTIFY_CONNECT 1
+#define ZMQ_NOTIFY_DISCONNECT 2
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd and thread-safe sockets                      */
@@ -693,34 +722,6 @@ ZMQ_EXPORT int zmq_poller_remove_fd (void *poller, int fd);
 ZMQ_EXPORT int zmq_socket_get_peer_state (void *socket,
                                           const void *routing_id,
                                           size_t routing_id_size);
-
-/******************************************************************************/
-/*  Scheduling timers                                                         */
-/******************************************************************************/
-
-#define ZMQ_HAVE_TIMERS
-
-typedef void(zmq_timer_fn) (int timer_id, void *arg);
-
-ZMQ_EXPORT void *zmq_timers_new (void);
-ZMQ_EXPORT int zmq_timers_destroy (void **timers_p);
-ZMQ_EXPORT int
-zmq_timers_add (void *timers, size_t interval, zmq_timer_fn handler, void *arg);
-ZMQ_EXPORT int zmq_timers_cancel (void *timers, int timer_id);
-ZMQ_EXPORT int
-zmq_timers_set_interval (void *timers, int timer_id, size_t interval);
-ZMQ_EXPORT int zmq_timers_reset (void *timers, int timer_id);
-ZMQ_EXPORT long zmq_timers_timeout (void *timers);
-ZMQ_EXPORT int zmq_timers_execute (void *timers);
-
-/******************************************************************************/
-/*  GSSAPI definitions                                                        */
-/******************************************************************************/
-
-/*  GSSAPI principal name types                                               */
-#define ZMQ_GSSAPI_NT_HOSTBASED 0
-#define ZMQ_GSSAPI_NT_USER_NAME 1
-#define ZMQ_GSSAPI_NT_KRB5_PRINCIPAL 2
 
 #endif // ZMQ_BUILD_DRAFT_API
 

--- a/C/zmq_utils.h
+++ b/C/zmq_utils.h
@@ -34,14 +34,16 @@
     compilers even have an equivalent concept.
     So in the worst case, this include file is treated as silently empty. */
 
-#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER)
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)               \
+  || defined(_MSC_VER)
 #if defined(__GNUC__) || defined(__GNUG__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic warning "-Wcpp"
 #pragma GCC diagnostic ignored "-Werror"
 #pragma GCC diagnostic ignored "-Wall"
 #endif
-#pragma message("Warning: zmq_utils.h is deprecated. All its functionality is provided by zmq.h.")
+#pragma message(                                                               \
+  "Warning: zmq_utils.h is deprecated. All its functionality is provided by zmq.h.")
 #if defined(__GNUC__) || defined(__GNUG__)
 #pragma GCC diagnostic pop
 #endif

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -350,11 +350,6 @@ enum
     ZMQ_EVENT_ALL                = 0xFFFF,
 }
 
-/*  Socket event data  */
-struct zmq_event_t {
-    ushort event;   // id of the event as bitfield
-    int value;      // value is either error code, fd or reconnect interval
-}
 
 void* zmq_socket(void*, int type);
 int zmq_close(void* s);

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -42,12 +42,9 @@ nothrow extern (C)
 {
 
 /*  Version macros for compile-time API version detection                     */
-enum
-{
-    ZMQ_VERSION_MAJOR   = 4,
-    ZMQ_VERSION_MINOR   = 2,
-    ZMQ_VERSION_PATCH   = 3
-}
+enum ZMQ_VERSION_MAJOR = 4;
+enum ZMQ_VERSION_MINOR = 2;
+enum ZMQ_VERSION_PATCH = 4;
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)
 {
@@ -112,7 +109,7 @@ void zmq_version (int *major, int *minor, int *patch);
 /*  Context options                                                           */
 enum
 {
-    ZMQ_IO_THREADS  = 1,
+    ZMQ_IO_THREADS = 1,
     ZMQ_MAX_SOCKETS = 2,
     ZMQ_SOCKET_LIMIT = 3,
     ZMQ_THREAD_PRIORITY = 3,
@@ -123,7 +120,7 @@ enum
 /*  Default for new contexts                                                  */
 enum
 {
-    ZMQ_IO_THREADS_DFLT  = 1,
+    ZMQ_IO_THREADS_DFLT = 1,
     ZMQ_MAX_SOCKETS_DFLT = 1023,
     ZMQ_THREAD_PRIORITY_DFLT = -1,
     ZMQ_THREAD_SCHED_POLICY_DFLT = -1,
@@ -156,8 +153,8 @@ struct zmq_msg_t
 
 int zmq_msg_init(zmq_msg_t* msg);
 int zmq_msg_init_size(zmq_msg_t* msg, size_t size);
-int zmq_msg_init_data(zmq_msg_t* msg, void* data, size_t size,
-    void function(void* data, void* hint) nothrow ffn, void* hint);
+int zmq_msg_init_data(
+    zmq_msg_t* msg, void* data, size_t size, void function(void* data, void* hint) nothrow ffn, void* hint);
 int zmq_msg_send(zmq_msg_t* msg, void* s, int flags);
 int zmq_msg_recv(zmq_msg_t* msg, void* s, int flags);
 int zmq_msg_close(zmq_msg_t* msg);
@@ -168,7 +165,8 @@ size_t zmq_msg_size(const(zmq_msg_t)* msg);
 int zmq_msg_more(const(zmq_msg_t)* msg);
 int zmq_msg_get(const(zmq_msg_t)* msg, int property);
 int zmq_msg_set(zmq_msg_t* msg, int property, int optval);
-const(char)* zmq_msg_gets(const(zmq_msg_t)* msg, const(char)* property);
+const(char)* zmq_msg_gets(const(zmq_msg_t)* msg,
+                          const(char)* property);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -301,32 +299,23 @@ enum
 }
 
 /*  RADIO_DISH protocol                                                       */
-enum
-{
-    ZMQ_GROUP_MAX_LENGTH = 15,
-}
+enum ZMQ_GROUP_MAX_LENGTH = 15;
 
 /*  Deprecated options and aliases                                            */
-enum
-{
-    ZMQ_IDENTITY                = ZMQ_ROUTING_ID,
-    ZMQ_CONNECT_RID             = ZMQ_CONNECT_ROUTING_ID,
-    ZMQ_TCP_ACCEPT_FILTER       = 38,
-    ZMQ_IPC_FILTER_PID          = 58,
-    ZMQ_IPC_FILTER_UID          = 59,
-    ZMQ_IPC_FILTER_GID          = 60,
-    ZMQ_IPV4ONLY                = 31,
-    ZMQ_DELAY_ATTACH_ON_CONNECT = ZMQ_IMMEDIATE,
-    ZMQ_NOBLOCK                 = ZMQ_DONTWAIT,
-    ZMQ_FAIL_UNROUTABLE         = ZMQ_ROUTER_MANDATORY,
-    ZMQ_ROUTER_BEHAVIOR         = ZMQ_ROUTER_MANDATORY,
-}
+enum ZMQ_IDENTITY = ZMQ_ROUTING_ID;
+enum ZMQ_CONNECT_RID = ZMQ_CONNECT_ROUTING_ID;
+enum ZMQ_TCP_ACCEPT_FILTER = 38;
+enum ZMQ_IPC_FILTER_PID = 58;
+enum ZMQ_IPC_FILTER_UID = 59;
+enum ZMQ_IPC_FILTER_GID = 60;
+enum ZMQ_IPV4ONLY = 31;
+enum ZMQ_DELAY_ATTACH_ON_CONNECT = ZMQ_IMMEDIATE;
+enum ZMQ_NOBLOCK = ZMQ_DONTWAIT;
+enum ZMQ_FAIL_UNROUTABLE = ZMQ_ROUTER_MANDATORY;
+enum ZMQ_ROUTER_BEHAVIOR = ZMQ_ROUTER_MANDATORY;
 
 /* Deprecated Message options                                                 */
-enum
-{
-    ZMQ_SRCFD = 2,
-}
+enum ZMQ_SRCFD = 2;
 
 /******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
@@ -334,22 +323,18 @@ enum
 
 /*  Socket transport events (TCP, IPC, and TIPC only)                                */
 
-enum
-{
-    ZMQ_EVENT_CONNECTED          = 0x0001,
-    ZMQ_EVENT_CONNECT_DELAYED    = 0x0002,
-    ZMQ_EVENT_CONNECT_RETRIED    = 0x0004,
-    ZMQ_EVENT_LISTENING          = 0x0008,
-    ZMQ_EVENT_BIND_FAILED        = 0x0010,
-    ZMQ_EVENT_ACCEPTED           = 0x0020,
-    ZMQ_EVENT_ACCEPT_FAILED      = 0x0040,
-    ZMQ_EVENT_CLOSED             = 0x0080,
-    ZMQ_EVENT_CLOSE_FAILED       = 0x0100,
-    ZMQ_EVENT_DISCONNECTED       = 0x0200,
-    ZMQ_EVENT_MONITOR_STOPPED    = 0x0400,
-    ZMQ_EVENT_ALL                = 0xFFFF,
-}
-
+enum ZMQ_EVENT_CONNECTED = 0x0001;
+enum ZMQ_EVENT_CONNECT_DELAYED = 0x0002;
+enum ZMQ_EVENT_CONNECT_RETRIED = 0x0004;
+enum ZMQ_EVENT_LISTENING = 0x0008;
+enum ZMQ_EVENT_BIND_FAILED = 0x0010;
+enum ZMQ_EVENT_ACCEPTED = 0x0020;
+enum ZMQ_EVENT_ACCEPT_FAILED = 0x0040;
+enum ZMQ_EVENT_CLOSED = 0x0080;
+enum ZMQ_EVENT_CLOSE_FAILED = 0x0100;
+enum ZMQ_EVENT_DISCONNECTED = 0x0200;
+enum ZMQ_EVENT_MONITOR_STOPPED = 0x0400;
+enum ZMQ_EVENT_ALL = 0xFFFF;
 
 void* zmq_socket(void*, int type);
 int zmq_close(void* s);
@@ -402,7 +387,10 @@ int zmq_poll(zmq_pollitem_t* items, int nitems, c_long timeout);
 /******************************************************************************/
 
 int zmq_proxy(void* frontend, void* backend, void* capture);
-int zmq_proxy_steerable (void *frontend, void *backend, void *capture, void *control);
+int zmq_proxy_steerable(void* frontend,
+                        void* backend,
+                        void* capture,
+                        void* control);
 
 /******************************************************************************/
 /*  Probe library capabilities                                                */
@@ -443,7 +431,8 @@ int zmq_curve_keypair(char* z85_public_key, char* z85_secret_key);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-int zmq_curve_public(char* z85_public_key, const(char)* z85_secret_key);
+int zmq_curve_public(char* z85_public_key,
+                     const(char)* z85_secret_key);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
@@ -467,8 +456,15 @@ void zmq_atomic_counter_destroy(void** counter_p);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 void* zmq_stopwatch_start();
 
+version (ZMQ_BUILD_DRAFT_API)
+{
+/*  Returns the number of microseconds elapsed since the stopwatch was        */
+/*  started, but does not stop or deallocate the stopwatch.                   */
+c_ulong zmq_stopwatch_intermediate(void* watch_);
+}
+
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
-/*  the stopwatch was started.                                                */
+/*  the stopwatch was started, and deallocates that watch.                    */
 c_ulong zmq_stopwatch_stop(void* watch_);
 
 /*  Sleeps for specified number of seconds.                                   */
@@ -504,6 +500,8 @@ enum ZMQ_GSSAPI_PRINCIPAL_NAMETYPE = 90;
 enum ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE = 91;
 enum ZMQ_BINDTODEVICE = 92;
 enum ZMQ_ZAP_ENFORCE_DOMAIN = 93;
+enum ZMQ_LOOPBACK_FASTPATH = 94;
+enum ZMQ_METADATA = 95;
 
 
 /*  DRAFT 0MQ socket events and monitoring                                    */
@@ -548,6 +546,7 @@ enum ZMQ_MSG_T_SIZE = 6;
 enum ZMQ_THREAD_AFFINITY_CPU_ADD = 7;
 enum ZMQ_THREAD_AFFINITY_CPU_REMOVE = 8;
 enum ZMQ_THREAD_NAME_PREFIX = 9;
+enum ZMQ_ZERO_COPY_RECV = 10;
 
 /*  DRAFT Socket methods.                                                     */
 int zmq_join(void* s, const(char)* group);
@@ -560,10 +559,10 @@ int zmq_msg_set_group(zmq_msg_t* msg, const(char)* group);
 const(char)* zmq_msg_group(zmq_msg_t* msg);
 
 /*  DRAFT Msg property names.                                                 */
-enum ZMQ_MSG_PROPERTY_ROUTING_ID    = "Routing-Id";
-enum ZMQ_MSG_PROPERTY_SOCKET_TYPE   = "Socket-Type";
-enum ZMQ_MSG_PROPERTY_USER_ID       = "User-Id";
-enum ZMQ_MSG_PROPERTY_PEER_ADDRESS  = "Peer-Address";
+enum ZMQ_MSG_PROPERTY_ROUTING_ID = "Routing-Id";
+enum ZMQ_MSG_PROPERTY_SOCKET_TYPE = "Socket-Type";
+enum ZMQ_MSG_PROPERTY_USER_ID = "User-Id";
+enum ZMQ_MSG_PROPERTY_PEER_ADDRESS = "Peer-Address";
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd, and thread-safe sockets                     */
@@ -585,12 +584,15 @@ struct zmq_poller_event_t
 }
 
 void* zmq_poller_new();
-int  zmq_poller_destroy(void** poller_p);
-int  zmq_poller_add(void* poller, void* socket, void* user_data, short events);
-int  zmq_poller_modify(void* poller, void* socket, short events);
-int  zmq_poller_remove(void* poller, void* socket);
-int  zmq_poller_wait(void* poller, zmq_poller_event_t* event, c_long timeout);
-int  zmq_poller_wait_all(void* poller, zmq_poller_event_t* events, int n_events, c_long timout);
+int zmq_poller_destroy(void** poller_p);
+int zmq_poller_add(void* poller, void* socket, void* user_data, short events);
+int zmq_poller_modify(void* poller, void* socket, short events);
+int zmq_poller_remove(void* poller, void* socket);
+int zmq_poller_wait(void* poller, zmq_poller_event_t* event, c_long timeout);
+int zmq_poller_wait_all(void* poller,
+                        zmq_poller_event_t* events,
+                        int n_events,
+                        c_long timout);
 
 version (Windows)
 {
@@ -615,14 +617,14 @@ int zmq_socket_get_peer_state(void* socket,
 
 alias zmq_timer_fn = void function(int timer_id, void* arg);
 
-void*  zmq_timers_new();
-int    zmq_timers_destroy(void** timers_p);
-int    zmq_timers_add(void* timers, size_t interval, zmq_timer_fn handler, void* arg);
-int    zmq_timers_cancel(void* timers, int timer_id);
-int    zmq_timers_set_interval(void* timers, int timer_id, size_t interval);
-int    zmq_timers_reset(void* timers, int timer_id);
+void* zmq_timers_new();
+int zmq_timers_destroy(void** timers_p);
+int zmq_timers_add(void* timers, size_t interval, zmq_timer_fn handler, void* arg);
+int zmq_timers_cancel(void* timers, int timer_id);
+int zmq_timers_set_interval(void* timers, int timer_id, size_t interval);
+int zmq_timers_reset(void* timers, int timer_id);
 c_long zmq_timers_timeout(void* timers);
-int    zmq_timers_execute(void* timers);
+int zmq_timers_execute(void* timers);
 
 /******************************************************************************/
 /*  GSSAPI definitions                                                        */

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -43,8 +43,8 @@ nothrow extern (C)
 
 /*  Version macros for compile-time API version detection                     */
 enum ZMQ_VERSION_MAJOR = 4;
-enum ZMQ_VERSION_MINOR = 2;
-enum ZMQ_VERSION_PATCH = 5;
+enum ZMQ_VERSION_MINOR = 3;
+enum ZMQ_VERSION_PATCH = 0;
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)
 {
@@ -97,25 +97,26 @@ enum
 int zmq_errno();
 
 /*  Resolves system errors and 0MQ errors to human-readable string.           */
-const(char)* zmq_strerror(int errnum);
+const(char)* zmq_strerror(int errnum_);
 
 /*  Run-time API version detection                                            */
-void zmq_version (int *major, int *minor, int *patch);
+void zmq_version (int* major_, int* minor_, int* patch_);
 
 /******************************************************************************/
 /*  0MQ infrastructure (a.k.a. context) initialisation & termination.         */
 /******************************************************************************/
 
 /*  Context options                                                           */
-enum
-{
-    ZMQ_IO_THREADS = 1,
-    ZMQ_MAX_SOCKETS = 2,
-    ZMQ_SOCKET_LIMIT = 3,
-    ZMQ_THREAD_PRIORITY = 3,
-    ZMQ_THREAD_SCHED_POLICY = 4,
-    ZMQ_MAX_MSGSZ = 5,
-}
+enum ZMQ_IO_THREADS = 1;
+enum ZMQ_MAX_SOCKETS = 2;
+enum ZMQ_SOCKET_LIMIT = 3;
+enum ZMQ_THREAD_PRIORITY = 3;
+enum ZMQ_THREAD_SCHED_POLICY = 4;
+enum ZMQ_MAX_MSGSZ = 5;
+enum ZMQ_MSG_T_SIZE = 6;
+enum ZMQ_THREAD_AFFINITY_CPU_ADD = 7;
+enum ZMQ_THREAD_AFFINITY_CPU_REMOVE = 8;
+enum ZMQ_THREAD_NAME_PREFIX = 9;
 
 /*  Default for new contexts                                                  */
 enum
@@ -127,15 +128,15 @@ enum
 }
 
 void* zmq_ctx_new();
-int zmq_ctx_term(void* context);
-int zmq_ctx_shutdown(void* context);
-int zmq_ctx_set(void* context, int option, int optval);
-int zmq_ctx_get(void* context, int option);
+int zmq_ctx_term(void* context_);
+int zmq_ctx_shutdown(void* context_);
+int zmq_ctx_set(void* context_, int option_, int optval_);
+int zmq_ctx_get(void* context_, int option_);
 
 /*  Old (legacy) API                                                          */
-void* zmq_init(int io_threads);
-int zmq_term(void* context);
-int zmq_ctx_destroy(void* context);
+void* zmq_init(int io_threads_);
+int zmq_term(void* context_);
+int zmq_ctx_destroy(void* context_);
 
 
 /******************************************************************************/
@@ -151,22 +152,22 @@ struct zmq_msg_t
     align((void*).sizeof) ubyte[64] _;
 }
 
-int zmq_msg_init(zmq_msg_t* msg);
-int zmq_msg_init_size(zmq_msg_t* msg, size_t size);
+int zmq_msg_init(zmq_msg_t* msg_);
+int zmq_msg_init_size(zmq_msg_t* msg_, size_t size_);
 int zmq_msg_init_data(
-    zmq_msg_t* msg, void* data, size_t size, void function(void* data, void* hint) nothrow ffn, void* hint);
-int zmq_msg_send(zmq_msg_t* msg, void* s, int flags);
-int zmq_msg_recv(zmq_msg_t* msg, void* s, int flags);
-int zmq_msg_close(zmq_msg_t* msg);
-int zmq_msg_move(zmq_msg_t* dest, zmq_msg_t* src);
-int zmq_msg_copy(zmq_msg_t* dest, zmq_msg_t* src);
-void* zmq_msg_data(zmq_msg_t* msg);
-size_t zmq_msg_size(const(zmq_msg_t)* msg);
-int zmq_msg_more(const(zmq_msg_t)* msg);
-int zmq_msg_get(const(zmq_msg_t)* msg, int property);
-int zmq_msg_set(zmq_msg_t* msg, int property, int optval);
-const(char)* zmq_msg_gets(const(zmq_msg_t)* msg,
-                          const(char)* property);
+    zmq_msg_t* msg_, void* data_, size_t size_, void function(void* data_, void* hint_) nothrow ffn_, void* hint_);
+int zmq_msg_send(zmq_msg_t* msg_, void* s_, int flags_);
+int zmq_msg_recv(zmq_msg_t* msg_, void* s_, int flags_);
+int zmq_msg_close(zmq_msg_t* msg_);
+int zmq_msg_move(zmq_msg_t* dest_, zmq_msg_t* src_);
+int zmq_msg_copy(zmq_msg_t* dest_, zmq_msg_t* src_);
+void* zmq_msg_data(zmq_msg_t* msg_);
+size_t zmq_msg_size(const(zmq_msg_t)* msg_);
+int zmq_msg_more(const(zmq_msg_t)* msg_);
+int zmq_msg_get(const(zmq_msg_t)* msg_, int property_);
+int zmq_msg_set(zmq_msg_t* msg_, int property_, int optval_);
+const(char)* zmq_msg_gets(const(zmq_msg_t)* msg_,
+                          const(char)* property_);
 
 /******************************************************************************/
 /*  0MQ socket definition.                                                    */
@@ -197,82 +198,82 @@ enum
 }
 
 /*  Socket options.                                                           */
-enum
-{
-    ZMQ_AFFINITY        = 4,
-    ZMQ_ROUTING_ID      = 5,
-    ZMQ_SUBSCRIBE       = 6,
-    ZMQ_UNSUBSCRIBE     = 7,
-    ZMQ_RATE            = 8,
-    ZMQ_RECOVERY_IVL    = 9,
-    ZMQ_SNDBUF          = 11,
-    ZMQ_RCVBUF          = 12,
-    ZMQ_RCVMORE         = 13,
-    ZMQ_FD              = 14,
-    ZMQ_EVENTS          = 15,
-    ZMQ_TYPE            = 16,
-    ZMQ_LINGER          = 17,
-    ZMQ_RECONNECT_IVL   = 18,
-    ZMQ_BACKLOG         = 19,
-    ZMQ_RECONNECT_IVL_MAX = 21,
-    ZMQ_MAXMSGSIZE      = 22,
-    ZMQ_SNDHWM          = 23,
-    ZMQ_RCVHWM          = 24,
-    ZMQ_MULTICAST_HOPS  = 25,
-    ZMQ_RCVTIMEO        = 27,
-    ZMQ_SNDTIMEO        = 28,
-    ZMQ_LAST_ENDPOINT   = 32,
-    ZMQ_ROUTER_MANDATORY        = 33,
-    ZMQ_TCP_KEEPALIVE           = 34,
-    ZMQ_TCP_KEEPALIVE_CNT       = 35,
-    ZMQ_TCP_KEEPALIVE_IDLE      = 36,
-    ZMQ_TCP_KEEPALIVE_INTVL     = 37,
-    ZMQ_IMMEDIATE               = 39,
-    ZMQ_XPUB_VERBOSE            = 40,
-    ZMQ_ROUTER_RAW              = 41,
-    ZMQ_IPV6                    = 42,
-    ZMQ_MECHANISM               = 43,
-    ZMQ_PLAIN_SERVER            = 44,
-    ZMQ_PLAIN_USERNAME          = 45,
-    ZMQ_PLAIN_PASSWORD          = 46,
-    ZMQ_CURVE_SERVER            = 47,
-    ZMQ_CURVE_PUBLICKEY         = 48,
-    ZMQ_CURVE_SECRETKEY         = 49,
-    ZMQ_CURVE_SERVERKEY         = 50,
-    ZMQ_PROBE_ROUTER            = 51,
-    ZMQ_REQ_CORRELATE           = 52,
-    ZMQ_REQ_RELAXED             = 53,
-    ZMQ_CONFLATE                = 54,
-    ZMQ_ZAP_DOMAIN              = 55,
-    ZMQ_ROUTER_HANDOVER         = 56,
-    ZMQ_TOS                     = 57,
-    ZMQ_CONNECT_ROUTING_ID      = 61,
-    ZMQ_GSSAPI_SERVER           = 62,
-    ZMQ_GSSAPI_PRINCIPAL        = 63,
-    ZMQ_GSSAPI_SERVICE_PRINCIPAL= 64,
-    ZMQ_GSSAPI_PLAINTEXT        = 65,
-    ZMQ_HANDSHAKE_IVL           = 66,
-    ZMQ_SOCKS_PROXY             = 68,
-    ZMQ_XPUB_NODROP             = 69,
-    ZMQ_BLOCKY                  = 70,
-    ZMQ_XPUB_MANUAL             = 71,
-    ZMQ_XPUB_WELCOME_MSG        = 72,
-    ZMQ_STREAM_NOTIFY           = 73,
-    ZMQ_INVERT_MATCHING         = 74,
-    ZMQ_HEARTBEAT_IVL           = 75,
-    ZMQ_HEARTBEAT_TTL           = 76,
-    ZMQ_HEARTBEAT_TIMEOUT       = 77,
-    ZMQ_XPUB_VERBOSER           = 78,
-    ZMQ_CONNECT_TIMOUT          = 79,
-    ZMQ_TCP_MAXRT               = 80,
-    ZMQ_THREAD_SAFE             = 81,
-    ZMQ_MULTICAST_MAXTPDU       = 84,
-    ZMQ_VMCI_BUFFER_SIZE        = 85,
-    ZMQ_VMCI_BUFFER_MIN_SIZE    = 86,
-    ZMQ_VMCI_BUFFER_MAX_SIZE    = 87,
-    ZMQ_VMCI_CONNECT_TIMEOUT    = 88,
-    ZMQ_USE_FD                  = 89,
-}
+enum ZMQ_AFFINITY = 4;
+enum ZMQ_ROUTING_ID = 5;
+enum ZMQ_SUBSCRIBE = 6;
+enum ZMQ_UNSUBSCRIBE = 7;
+enum ZMQ_RATE = 8;
+enum ZMQ_RECOVERY_IVL = 9;
+enum ZMQ_SNDBUF = 11;
+enum ZMQ_RCVBUF = 12;
+enum ZMQ_RCVMORE = 13;
+enum ZMQ_FD = 14;
+enum ZMQ_EVENTS = 15;
+enum ZMQ_TYPE = 16;
+enum ZMQ_LINGER = 17;
+enum ZMQ_RECONNECT_IVL = 18;
+enum ZMQ_BACKLOG = 19;
+enum ZMQ_RECONNECT_IVL_MAX = 21;
+enum ZMQ_MAXMSGSIZE = 22;
+enum ZMQ_SNDHWM = 23;
+enum ZMQ_RCVHWM = 24;
+enum ZMQ_MULTICAST_HOPS = 25;
+enum ZMQ_RCVTIMEO = 27;
+enum ZMQ_SNDTIMEO = 28;
+enum ZMQ_LAST_ENDPOINT = 32;
+enum ZMQ_ROUTER_MANDATORY = 33;
+enum ZMQ_TCP_KEEPALIVE = 34;
+enum ZMQ_TCP_KEEPALIVE_CNT = 35;
+enum ZMQ_TCP_KEEPALIVE_IDLE = 36;
+enum ZMQ_TCP_KEEPALIVE_INTVL = 37;
+enum ZMQ_IMMEDIATE = 39;
+enum ZMQ_XPUB_VERBOSE = 40;
+enum ZMQ_ROUTER_RAW = 41;
+enum ZMQ_IPV6 = 42;
+enum ZMQ_MECHANISM = 43;
+enum ZMQ_PLAIN_SERVER = 44;
+enum ZMQ_PLAIN_USERNAME = 45;
+enum ZMQ_PLAIN_PASSWORD = 46;
+enum ZMQ_CURVE_SERVER = 47;
+enum ZMQ_CURVE_PUBLICKEY = 48;
+enum ZMQ_CURVE_SECRETKEY = 49;
+enum ZMQ_CURVE_SERVERKEY = 50;
+enum ZMQ_PROBE_ROUTER = 51;
+enum ZMQ_REQ_CORRELATE = 52;
+enum ZMQ_REQ_RELAXED = 53;
+enum ZMQ_CONFLATE = 54;
+enum ZMQ_ZAP_DOMAIN = 55;
+enum ZMQ_ROUTER_HANDOVER = 56;
+enum ZMQ_TOS = 57;
+enum ZMQ_CONNECT_ROUTING_ID = 61;
+enum ZMQ_GSSAPI_SERVER = 62;
+enum ZMQ_GSSAPI_PRINCIPAL = 63;
+enum ZMQ_GSSAPI_SERVICE_PRINCIPAL= 64;
+enum ZMQ_GSSAPI_PLAINTEXT = 65;
+enum ZMQ_HANDSHAKE_IVL = 66;
+enum ZMQ_SOCKS_PROXY = 68;
+enum ZMQ_XPUB_NODROP = 69;
+enum ZMQ_BLOCKY = 70;
+enum ZMQ_XPUB_MANUAL = 71;
+enum ZMQ_XPUB_WELCOME_MSG = 72;
+enum ZMQ_STREAM_NOTIFY = 73;
+enum ZMQ_INVERT_MATCHING = 74;
+enum ZMQ_HEARTBEAT_IVL = 75;
+enum ZMQ_HEARTBEAT_TTL = 76;
+enum ZMQ_HEARTBEAT_TIMEOUT = 77;
+enum ZMQ_XPUB_VERBOSER = 78;
+enum ZMQ_CONNECT_TIMOUT = 79;
+enum ZMQ_TCP_MAXRT = 80;
+enum ZMQ_THREAD_SAFE = 81;
+enum ZMQ_MULTICAST_MAXTPDU = 84;
+enum ZMQ_VMCI_BUFFER_SIZE = 85;
+enum ZMQ_VMCI_BUFFER_MIN_SIZE = 86;
+enum ZMQ_VMCI_BUFFER_MAX_SIZE = 87;
+enum ZMQ_VMCI_CONNECT_TIMEOUT = 88;
+enum ZMQ_USE_FD = 89;
+enum ZMQ_GSSAPI_PRINCIPAL_NAMETYPE = 90;
+enum ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE = 91;
+enum ZMQ_BINDTODEVICE = 92;
 
 
 /*  Message options                                                           */
@@ -318,6 +319,15 @@ enum ZMQ_ROUTER_BEHAVIOR = ZMQ_ROUTER_MANDATORY;
 enum ZMQ_SRCFD = 2;
 
 /******************************************************************************/
+/*  GSSAPI definitions                                                        */
+/******************************************************************************/
+
+/*  GSSAPI principal name types                                               */
+enum ZMQ_GSSAPI_NT_HOSTBASED = 0;
+enum ZMQ_GSSAPI_NT_USER_NAME = 1;
+enum ZMQ_GSSAPI_NT_KRB5_PRINCIPAL = 2;
+
+/******************************************************************************/
 /*  0MQ socket events and monitoring                                          */
 /******************************************************************************/
 
@@ -335,19 +345,51 @@ enum ZMQ_EVENT_CLOSE_FAILED = 0x0100;
 enum ZMQ_EVENT_DISCONNECTED = 0x0200;
 enum ZMQ_EVENT_MONITOR_STOPPED = 0x0400;
 enum ZMQ_EVENT_ALL = 0xFFFF;
+/*  Unspecified system errors during handshake. Event value is an errno.      */
+enum ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL = 0x0800;
+/*  Handshake complete successfully with successful authentication (if        *
+ *  enabled). Event value is unused.                                          */
+enum ZMQ_EVENT_HANDSHAKE_SUCCEEDED = 0x1000;
+/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
+ *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
+enum ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL = 0x2000;
+/*  Failed authentication requests. Event value is the numeric ZAP status     *
+ *  code, i.e. 300, 400 or 500.                                               */
+enum ZMQ_EVENT_HANDSHAKE_FAILED_AUTH = 0x4000;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED = 0x10000000;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND = 0x10000001;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE = 0x10000002;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE = 0x10000003;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED = 0x10000011;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE = 0x10000012;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO = 0x10000013;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE = 0x10000014;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR = 0x10000015;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY = 0x10000016;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME = 0x10000017;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA = 0x10000018;
+// the following two may be due to erroneous configuration of a peer
+enum ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC = 0x11000001;
+enum ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH = 0x11000002;
+enum ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED = 0x20000000;
+enum ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY = 0x20000001;
+enum ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID = 0x20000002;
+enum ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION = 0x20000003;
+enum ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE = 0x20000004;
+enum ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA = 0x20000005;
 
-void* zmq_socket(void*, int type);
-int zmq_close(void* s);
-int zmq_setsockopt(void* s, int option, const void* optval, size_t optvallen);
-int zmq_getsockopt(void* s, int option, void* optval, size_t *optvallen);
-int zmq_bind(void* s, const char* addr);
-int zmq_connect(void* s, const char* addr);
-int zmq_unbind(void* s, const char* addr);
-int zmq_disconnect(void* s, const char* addr);
-int zmq_send(void* s, const void* buf, size_t len, int flags);
-int zmq_send_const(void *s, const void* buf, size_t len, int flags);
-int zmq_recv(void* s, void* buf, size_t len, int flags);
-int zmq_socket_monitor(void* s, const char* addr, int events);
+void* zmq_socket(void*, int type_);
+int zmq_close(void* s_);
+int zmq_setsockopt(void* s_, int option_, const void* optval_, size_t optvallen_);
+int zmq_getsockopt(void* s_, int option_, void* optval_, size_t *optvallen_);
+int zmq_bind(void* s_, const char* addr_);
+int zmq_connect(void* s_, const char* addr_);
+int zmq_unbind(void* s_, const char* addr_);
+int zmq_disconnect(void* s_, const char* addr_);
+int zmq_send(void* s_, const void* buf_, size_t len_, int flags_);
+int zmq_send_const(void *s_, const void* buf_, size_t len_, int flags_);
+int zmq_recv(void* s_, void* buf_, size_t len_, int flags_);
+int zmq_socket_monitor(void* s_, const char* addr_, int events_);
 
 
 /******************************************************************************/
@@ -380,24 +422,24 @@ struct zmq_pollitem_t
 
 enum ZMQ_POLLITEMS_DFLT = 16;
 
-int zmq_poll(zmq_pollitem_t* items, int nitems, c_long timeout);
+int zmq_poll(zmq_pollitem_t* items_, int nitems_, c_long timeout_);
 
 /******************************************************************************/
 /*  Message proxying                                                          */
 /******************************************************************************/
 
-int zmq_proxy(void* frontend, void* backend, void* capture);
-int zmq_proxy_steerable(void* frontend,
-                        void* backend,
-                        void* capture,
-                        void* control);
+int zmq_proxy(void* frontend_, void* backend_, void* capture_);
+int zmq_proxy_steerable(void* frontend_,
+                        void* backend_,
+                        void* capture_,
+                        void* control_);
 
 /******************************************************************************/
 /*  Probe library capabilities                                                */
 /******************************************************************************/
 
 enum ZMQ_HAS_CAPABILITIES = 1;
-int zmq_has(const(char)* capability);
+int zmq_has(const(char)* capability_);
 
 /*  Deprecated aliases */
 enum
@@ -408,41 +450,59 @@ enum
 }
 
 /*  Deprecated methods */
-int zmq_device(int type, void* frontend, void* backend);
-int zmq_sendmsg(void* s, zmq_msg_t* msg, int flags);
-int zmq_recvmsg(void* s, zmq_msg_t* msg, int flags);
+int zmq_device(int type_, void* frontend_, void* backend_);
+int zmq_sendmsg(void* s_, zmq_msg_t* msg_, int flags_);
+int zmq_recvmsg(void* s_, zmq_msg_t* msg_, int flags_);
 struct iovec;
-int zmq_sendiov(void* s, iovec* iov, size_t count, int flags);
-int zmq_recviov(void* s, iovec* iov, size_t* count, int flags);
+int zmq_sendiov(void* s_, iovec* iov_, size_t count_, int flags_);
+int zmq_recviov(void* s_, iovec* iov_, size_t* count_, int flags_);
 
 /******************************************************************************/
 /*  Encryption functions                                                      */
 /******************************************************************************/
 
 /*  Encode data with Z85 encoding. Returns encoded data                       */
-char* zmq_z85_encode(char* dest, const(ubyte)* data, size_t size);
+char* zmq_z85_encode(char* dest_, const(ubyte)* data_, size_t size_);
 
 /*  Decode data with Z85 encoding. Returns decoded data                       */
-ubyte* zmq_z85_decode(ubyte* dest, const(char)* string_);
+ubyte* zmq_z85_decode(ubyte* dest_, const(char)* string_);
 
 /*  Generate z85-encoded public and private keypair with tweetnacl/libsodium. */
 /*  Returns 0 on success.                                                     */
-int zmq_curve_keypair(char* z85_public_key, char* z85_secret_key);
+int zmq_curve_keypair(char* z85_public_key_, char* z85_secret_key_);
 
 /*  Derive the z85-encoded public key from the z85-encoded secret key.        */
 /*  Returns 0 on success.                                                     */
-int zmq_curve_public(char* z85_public_key,
-                     const(char)* z85_secret_key);
+int zmq_curve_public(char* z85_public_key_,
+                     const(char)* z85_secret_key_);
 
 /******************************************************************************/
 /*  Atomic utility methods                                                    */
 /******************************************************************************/
 void* zmq_atomic_counter_new();
-void zmq_atomic_counter_set(void* counter, int value);
-int zmq_atomic_counter_inc(void* counter);
-int zmq_atomic_counter_dec(void* counter);
-int zmq_atomic_counter_value(void* counter);
-void zmq_atomic_counter_destroy(void** counter_p);
+void zmq_atomic_counter_set(void* counter_, int value_);
+int zmq_atomic_counter_inc(void* counter_);
+int zmq_atomic_counter_dec(void* counter_);
+int zmq_atomic_counter_value(void* counter_);
+void zmq_atomic_counter_destroy(void** counter_p_);
+
+/******************************************************************************/
+/*  Scheduling timers                                                         */
+/******************************************************************************/
+
+enum ZMQ_HAVE_TIMERS = true;
+
+alias zmq_timer_fn = void function(int timer_id, void* arg);
+
+void* zmq_timers_new();
+int zmq_timers_destroy(void** timers_p);
+int zmq_timers_add(void* timers, size_t interval, zmq_timer_fn handler, void* arg);
+int zmq_timers_cancel(void* timers, int timer_id);
+int zmq_timers_set_interval(void* timers, int timer_id, size_t interval);
+int zmq_timers_reset(void* timers, int timer_id);
+c_long zmq_timers_timeout(void* timers);
+int zmq_timers_execute(void* timers);
+
 
 /******************************************************************************/
 /*  These functions are not documented by man pages -- use at your own risk.  */
@@ -456,12 +516,9 @@ void zmq_atomic_counter_destroy(void** counter_p);
 /*  Starts the stopwatch. Returns the handle to the watch.                    */
 void* zmq_stopwatch_start();
 
-version (ZMQ_BUILD_DRAFT_API)
-{
 /*  Returns the number of microseconds elapsed since the stopwatch was        */
 /*  started, but does not stop or deallocate the stopwatch.                   */
 c_ulong zmq_stopwatch_intermediate(void* watch_);
-}
 
 /*  Stops the stopwatch. Returns the number of microseconds elapsed since     */
 /*  the stopwatch was started, and deallocates that watch.                    */
@@ -471,10 +528,10 @@ c_ulong zmq_stopwatch_stop(void* watch_);
 void zmq_sleep(int seconds_);
 
 /* Start a thread. Returns a handle to the thread.                            */
-void* zmq_threadstart(void function(void*) nothrow func, void* arg);
+void* zmq_threadstart(void function(void*) nothrow func_, void* arg_);
 
 /* Wait for thread to complete then free up resources.                        */
-void zmq_threadclose(void* thread);
+void zmq_threadclose(void* thread_);
 
 
 /******************************************************************************/
@@ -496,56 +553,13 @@ enum
 }
 
 /*  DRAFT Socket options.                                                     */
-enum ZMQ_GSSAPI_PRINCIPAL_NAMETYPE = 90;
-enum ZMQ_GSSAPI_SERVICE_PRINCIPAL_NAMETYPE = 91;
-enum ZMQ_BINDTODEVICE = 92;
 enum ZMQ_ZAP_ENFORCE_DOMAIN = 93;
 enum ZMQ_LOOPBACK_FASTPATH = 94;
 enum ZMQ_METADATA = 95;
-
-
-/*  DRAFT 0MQ socket events and monitoring                                    */
-/*  Unspecified system errors during handshake. Event value is an errno.      */
-enum ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL = 0x0800;
-/*  Handshake complete successfully with successful authentication (if        *
- *  enabled). Event value is unused.                                          */
-enum ZMQ_EVENT_HANDSHAKE_SUCCEEDED = 0x1000;
-/*  Protocol errors between ZMTP peers or between server and ZAP handler.     *
- *  Event value is one of ZMQ_PROTOCOL_ERROR_*                                */
-enum ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL = 0x2000;
-/*  Failed authentication requests. Event value is the numeric ZAP status     *
- *  code, i.e. 300, 400 or 500.                                               */
-enum ZMQ_EVENT_HANDSHAKE_FAILED_AUTH = 0x4000;
-
-enum ZMQ_PROTOCOL_ERROR_ZMTP_UNSPECIFIED = 0x10000000;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_UNEXPECTED_COMMAND = 0x10000001;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_SEQUENCE = 0x10000002;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_KEY_EXCHANGE = 0x10000003;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_UNSPECIFIED = 0x10000011;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_MESSAGE = 0x10000012;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_HELLO = 0x10000013;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_INITIATE = 0x10000014;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_ERROR = 0x10000015;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_READY = 0x10000016;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MALFORMED_COMMAND_WELCOME = 0x10000017;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_INVALID_METADATA = 0x10000018;
-
-// the following two may be due to erroneous configuration of a peer
-enum ZMQ_PROTOCOL_ERROR_ZMTP_CRYPTOGRAPHIC = 0x11000001;
-enum ZMQ_PROTOCOL_ERROR_ZMTP_MECHANISM_MISMATCH = 0x11000002;
-
-enum ZMQ_PROTOCOL_ERROR_ZAP_UNSPECIFIED = 0x20000000;
-enum ZMQ_PROTOCOL_ERROR_ZAP_MALFORMED_REPLY = 0x20000001;
-enum ZMQ_PROTOCOL_ERROR_ZAP_BAD_REQUEST_ID = 0x20000002;
-enum ZMQ_PROTOCOL_ERROR_ZAP_BAD_VERSION = 0x20000003;
-enum ZMQ_PROTOCOL_ERROR_ZAP_INVALID_STATUS_CODE = 0x20000004;
-enum ZMQ_PROTOCOL_ERROR_ZAP_INVALID_METADATA = 0x20000005;
+enum ZMQ_MULTICAST_LOOP = 96;
+enum ZMQ_ROUTER_NOTIFY = 97;
 
 /*  DRAFT Context options                                                     */
-enum ZMQ_MSG_T_SIZE = 6;
-enum ZMQ_THREAD_AFFINITY_CPU_ADD = 7;
-enum ZMQ_THREAD_AFFINITY_CPU_REMOVE = 8;
-enum ZMQ_THREAD_NAME_PREFIX = 9;
 enum ZMQ_ZERO_COPY_RECV = 10;
 
 /*  DRAFT Socket methods.                                                     */
@@ -563,6 +577,10 @@ enum ZMQ_MSG_PROPERTY_ROUTING_ID = "Routing-Id";
 enum ZMQ_MSG_PROPERTY_SOCKET_TYPE = "Socket-Type";
 enum ZMQ_MSG_PROPERTY_USER_ID = "User-Id";
 enum ZMQ_MSG_PROPERTY_PEER_ADDRESS = "Peer-Address";
+
+/*  Router notify options                                                     */
+enum ZMQ_NOTIFY_CONNECT = 1;
+enum ZMQ_NOTIFY_DISCONNECT = 2;
 
 /******************************************************************************/
 /*  Poller polling on sockets,fd, and thread-safe sockets                     */
@@ -610,30 +628,6 @@ else
 int zmq_socket_get_peer_state(void* socket,
                               const(void)* routing_id,
                               size_t routing_id_size);
-
-/******************************************************************************/
-/*  Scheduling timers                                                         */
-/******************************************************************************/
-
-alias zmq_timer_fn = void function(int timer_id, void* arg);
-
-void* zmq_timers_new();
-int zmq_timers_destroy(void** timers_p);
-int zmq_timers_add(void* timers, size_t interval, zmq_timer_fn handler, void* arg);
-int zmq_timers_cancel(void* timers, int timer_id);
-int zmq_timers_set_interval(void* timers, int timer_id, size_t interval);
-int zmq_timers_reset(void* timers, int timer_id);
-c_long zmq_timers_timeout(void* timers);
-int zmq_timers_execute(void* timers);
-
-/******************************************************************************/
-/*  GSSAPI definitions                                                        */
-/******************************************************************************/
-
-/*  GSSAPI principal name types                                               */
-enum ZMQ_GSSAPI_NT_HOSTBASED  = 0;
-enum ZMQ_GSSAPI_NT_USER_NAME  = 1;
-enum ZMQ_GSSAPI_NT_KRB5_PRINCIPAL  = 2;
 
 } // version(ZMQ_BUILD_DRAFT_API)
 

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -560,7 +560,7 @@ version (Windows)
 }
 else
 {
-    int zmq_poller_add_fd(void* poller, int fd, void* user_data, short_events);
+    int zmq_poller_add_fd(void* poller, int fd, void* user_data, short events);
     int zmq_poller_modify_fd(void* poller, int fd, short events);
     int zmq_poller_remove_fd(void* poller, int fd);
 }

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -44,7 +44,7 @@ nothrow extern (C)
 /*  Version macros for compile-time API version detection                     */
 enum ZMQ_VERSION_MAJOR = 4;
 enum ZMQ_VERSION_MINOR = 3;
-enum ZMQ_VERSION_PATCH = 0;
+enum ZMQ_VERSION_PATCH = 1;
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)
 {

--- a/deimos/zmq/zmq.d
+++ b/deimos/zmq/zmq.d
@@ -44,7 +44,7 @@ nothrow extern (C)
 /*  Version macros for compile-time API version detection                     */
 enum ZMQ_VERSION_MAJOR = 4;
 enum ZMQ_VERSION_MINOR = 2;
-enum ZMQ_VERSION_PATCH = 4;
+enum ZMQ_VERSION_PATCH = 5;
 
 int ZMQ_MAKE_VERSION(int major, int minor, int patch)
 {


### PR DESCRIPTION
This brings the bindings up to date with the latest release of ZeroMQ, version 4.3.2. I've made a separate commit per upstream version change (4.2.3 through 4.3.2), interspersed with some commits that fix old bugs that I discovered during translation.

As of earlier today (PR #33), the bindings versions are decoupled from the upstream versions. After merge, I'll tag these commits as follows:

* 4.2.3 -> `v5.0.1+zmq-4-2-3`
* 4.2.4 -> `v6.0.0+zmq-4-2-4` (This is unfortunate, and due to the removal of `zmq_event_t` (which should have been removed a long time ago). But I expect upstream-4.2 users will stay with 5.0, while upstream-4.3 users will switch 6.0)
* 4.2.5 -> `v6.0.1+zmq-4-2-5`
* 4.3.0 -> `v6.1.0+zmq-4-3-0`
* 4.3.1 -> `v6.1.1+zmq-4-3-1`
* 4.3.2 -> `v6.1.2+zmq-4-3-2`
